### PR TITLE
OnigCaptureTreeNode memory leak

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -95,6 +95,8 @@ history_tree_clear(OnigCaptureTreeNode* node)
     node->beg = ONIG_REGION_NOTPOS;
     node->end = ONIG_REGION_NOTPOS;
     node->group = -1;
+    xfree(node->childs);
+    node->childs = (OnigCaptureTreeNode** )0;
   }
 }
 


### PR DESCRIPTION
OnigCaptureTreeNode has memory leak issue.

Test code.

<pre><code>#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include "oniguruma.h"

int main() {
    const char *pattern = "\\g&lt;p&gt;(?@&lt;p&gt;\\(\\g&lt;s&gt;\\)){0}(?@&lt;s&gt;(?:\\g&lt;p&gt;)*|){0}";
    const char *str = "(((()()(()))(())())())";

    OnigSyntaxType syn;
    regex_t* reg;
    int r;
    OnigErrorInfo einfo;

    onig_copy_syntax(&syn, ONIG_SYNTAX_DEFAULT);
    onig_set_syntax_op2(&syn, onig_get_syntax_op2(&syn) | ONIG_SYN_OP2_ATMARK_CAPTURE_HISTORY);

    while (1) {
        onig_new(&reg, (const OnigUChar *)pattern, (const OnigUChar *)pattern + strlen((char *)pattern),
            (OnigOptionType)ONIG_OPTION_DEFAULT, ONIG_ENCODING_UTF8, &syn, &einfo);
        if (r != ONIG_NORMAL) {
            OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
            onig_error_code_to_str(s, r, &einfo);
            fprintf(stderr, "error:%s", s);
            exit(1);
        }
        OnigRegion *region = onig_region_new();
        if (region == NULL) {
            fprintf(stderr, "error:onig_region_new");
        }
        const OnigUChar *s, *e;
        s = (const OnigUChar *)str;
        e = s + strlen(str);
        r = onig_search(reg, s, e, s, e, region, ONIG_OPTION_NONE);
        onig_region_free(region, 1);

        onig_free(reg);
    }

    return 0;
}
</code></pre>
