### PR TITLE
Merge CRuby r38805

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -4039,7 +4039,7 @@ add_ctype_to_cc(CClassNode* cc, int ctype, int not, int char_prop, ScanEnv* env)
     r = add_ctype_to_cc_by_range(cc, ctype, not, env->enc, sb_out, ranges);
     if ((r == 0) && ascii_range) {
       if (not != 0) {
-	r = add_code_range_to_buf(&(cc->mbuf), 0x80, ONIG_LAST_CODE_POINT);
+	r = add_code_range_to_buf0(&(cc->mbuf), 0x80, ONIG_LAST_CODE_POINT, FALSE);
       }
       else {
 	CClassNode ccascii;


### PR DESCRIPTION
- regparse.c (add_ctype_to_cc): don't check dup warn on adding
  negative ctype to cclass. [Bug #7471] [ruby-core:50344]
