### PR TITLE
Fix a renumbering bug in condition regexp with a named capture.

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1937,7 +1937,12 @@ renumber_by_map(Node* node, GroupNumRemap* map)
     r = renumber_by_map(NQTFR(node)->target, map);
     break;
   case NT_ENCLOSE:
-    r = renumber_by_map(NENCLOSE(node)->target, map);
+    {
+      EncloseNode* en = NENCLOSE(node);
+      if (en->type == ENCLOSE_CONDITION)
+        en->regnum = map[en->regnum].new_val; 
+      r = renumber_by_map(en->target, map);
+    }
     break;
 
   case NT_BREF:

--- a/testpy.py
+++ b/testpy.py
@@ -1101,6 +1101,10 @@ def main():
     n("(?:(?<x>a)|(?<y>b))(?:(?(<y>)cd|x)e|fg)", "bxe")
     x2("((?<=a))?(?(1)b|c)", "abc", 1, 2)
     x2("((?<=a))?(?(1)b|c)", "bc", 1, 2)
+    x2("((?<x>x)|(?<y>y))(?(<x>)y|x)", "xy", 0, 2)
+    x2("((?<x>x)|(?<y>y))(?(<x>)y|x)", "yx", 0, 2)
+    n("((?<x>x)|(?<y>y))(?(<x>)y|x)", "xx")
+    n("((?<x>x)|(?<y>y))(?(<x>)y|x)", "yy")
 
     # Implicit-anchor optimization
     x2("(?m:.*abc)", "dddabdd\nddabc", 0, 13)   # optimized /(?m:.*abc)/ ==> /\A(?m:.*abc)/


### PR DESCRIPTION
Submitted by Ippei Obayashi in https://bugs.ruby-lang.org/issues/8583.
