### PR TITLE
Add -no-undefine link flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ libonig_la_SOURCES = regint.h regparse.h regenc.h st.h \
 	$(encdir)/euc_tw.c $(encdir)/euc_kr.c $(encdir)/big5.c \
 	$(encdir)/gb18030.c $(encdir)/koi8_r.c $(encdir)/cp1251.c
 
-libonig_la_LDFLAGS = -version-info $(LTVERSION)
+libonig_la_LDFLAGS = -version-info $(LTVERSION) -no-undefined
 
 EXTRA_DIST = .gitignore oniguruma.pc.in HISTORY README.ja index.html \
 	index_ja.html doc/API doc/API.ja doc/RE doc/RE.ja doc/FAQ doc/FAQ.ja \

--- a/Makefile.in
+++ b/Makefile.in
@@ -340,7 +340,7 @@ libonig_la_SOURCES = regint.h regparse.h regenc.h st.h \
 	$(encdir)/euc_tw.c $(encdir)/euc_kr.c $(encdir)/big5.c \
 	$(encdir)/gb18030.c $(encdir)/koi8_r.c $(encdir)/cp1251.c
 
-libonig_la_LDFLAGS = -version-info $(LTVERSION)
+libonig_la_LDFLAGS = -version-info $(LTVERSION) -no-undefined
 EXTRA_DIST = .gitignore oniguruma.pc.in HISTORY README.ja index.html \
 	index_ja.html doc/API doc/API.ja doc/RE doc/RE.ja doc/FAQ doc/FAQ.ja \
 	doc/UnicodeProps.txt \


### PR DESCRIPTION
It is needed to build DLL with libtool. I tested it by cross-compiling
on Debian GNU/Linux sid with x86_64-w64-mingw32-gcc.

GCC version:

```
% x86_64-w64-mingw32-gcc --version
x86_64-w64-mingw32-gcc (GCC) 4.9.1
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
