### PR TITLE
Add build_nmake script for building with nmake

### DIFF
--- a/build_nmake.cmd
+++ b/build_nmake.cmd
@@ -1,0 +1,3 @@
+@setlocal enabledelayedexpansion
+copy /Y "%~dp0win32\config.h" "%~dp0config.h"
+nmake -f "%~dp0win32\Makefile" %*


### PR DESCRIPTION
build_nmake.cmd:
    copies win32\config.h to config.h
    calls nmake with -f win32\Makefile and user supplied arguments (%*)
    so for e.g. for cleaning:
    > build_nmake clean