### PR TITLE
Add "const" to not changed strings

### DIFF
--- a/regposerr.c
+++ b/regposerr.c
@@ -44,7 +44,7 @@
 
 #define numberof(array) (int)(sizeof(array) / sizeof((array)[0]))
 
-static char* ESTRING[] = {
+static const char* ESTRING[] = {
   NULL,
   "failed to match",                         /* REG_NOMATCH    */
   "Invalid regular expression",              /* REG_BADPAT     */
@@ -74,7 +74,7 @@ extern size_t
 regerror(int posix_ecode, const regex_t* reg ARG_UNUSED, char* buf,
 	 size_t size)
 {
-  char* s;
+  const char* s;
   char tbuf[35];
   size_t len;
 


### PR DESCRIPTION
The current code doesn't have any problem. This change is just for
protecting future problems.

We can find codes of this type by "-Wwrite-strings" GCC option:

    % LANG=C make CFLAGS='-Wwrite-strings' regposerr.o
    gcc -DHAVE_CONFIG_H -I. -I. -I/tmp/local/include    -Wwrite-strings -MT regposerr.o -MD -MP -MF .deps/regposerr.Tpo -c -o regposerr.o regposerr.c
    regposerr.c:49:3: warning: initialization discards 'const' qualifier from pointer target type
       "failed to match",                         /* REG_NOMATCH    */
       ^
    regposerr.c:50:3: warning: initialization discards 'const' qualifier from pointer target type
       "Invalid regular expression",              /* REG_BADPAT     */
       ^
    ...
    regposerr.c: In function 'regerror':
    regposerr.c:86:7: warning: assignment discards 'const' qualifier from pointer target type
         s = "";
           ^