### PR TITLE
Implement Direct Threaded VM described in #51. Improving ~49%.

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -1403,34 +1403,224 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
   best_len = ONIG_MISMATCH;
   s = (UChar* )sstart;
   pkeep = (UChar* )sstart;
-  while (1) {
+
+
 #ifdef ONIG_DEBUG_MATCH
-    if (s) {
-      UChar *q, *bp, buf[50];
-      int len;
-      fprintf(stderr, "%4"PRIdPTR"> \"", (*p == OP_FINISH) ? (ptrdiff_t )-1 : s - str);
-      bp = buf;
-      q = s;
-      if (*p != OP_FINISH) {    /* s may not be a valid pointer if OP_FINISH. */
-	for (i = 0; i < 7 && q < end; i++) {
-	  len = enclen(encode, q);
-	  while (len-- > 0) *bp++ = *q++;
-	}
-      }
-      if (q < end) { xmemcpy(bp, "...\"", 4); bp += 4; }
-      else         { xmemcpy(bp, "\"",    1); bp += 1; }
-      *bp = 0;
-      fputs((char* )buf, stderr);
-      for (i = 0; i < 20 - (bp - buf); i++) fputc(' ', stderr);
-      fprintf(stderr, "%4"PRIdPTR":", (p == FinishCode) ? (ptrdiff_t )-1 : p - reg->p);
-      onig_print_compiled_byte_code(stderr, p, NULL, encode);
-      fprintf(stderr, "\n");
+#define OPCODE_EXEC_HOOK                                                \
+    if (s) {                                                            \
+      UChar *q, *bp, buf[50];                                           \
+      int len;                                                          \
+      fprintf(stderr, "%4"PRIdPTR"> \"", (*p == OP_FINISH) ? (ptrdiff_t )-1 : s - str); \
+      bp = buf;                                                         \
+      q = s;                                                            \
+      if (*p != OP_FINISH) {    /* s may not be a valid pointer if OP_FINISH. */ \
+	for (i = 0; i < 7 && q < end; i++) {                            \
+	  len = enclen(encode, q);                                      \
+	  while (len-- > 0) *bp++ = *q++;                               \
+	}                                                               \
+      }                                                                 \
+      if (q < end) { xmemcpy(bp, "...\"", 4); bp += 4; }                \
+      else         { xmemcpy(bp, "\"",    1); bp += 1; }                \
+      *bp = 0;                                                          \
+      fputs((char* )buf, stderr);                                       \
+      for (i = 0; i < 20 - (bp - buf); i++) fputc(' ', stderr);         \
+      fprintf(stderr, "%4"PRIdPTR":", (p == FinishCode) ? (ptrdiff_t )-1 : p - reg->p); \
+      onig_print_compiled_byte_code(stderr, p, NULL, encode);           \
+      fprintf(stderr, "\n");                                            \
     }
+#else
+#define OPCODE_EXEC_HOOK ((void) 0)
 #endif
 
-    sbegin = s;
-    switch (*p++) {
-    case OP_END:  MOP_IN(OP_END);
+
+#ifdef USE_DIRECT_THREADED_VM
+#define VM_LOOP JUMP;
+#define VM_LOOP_END
+#define CASE(x) L_##x: OPCODE_EXEC_HOOK;
+#define DEFAULT L_DEFAULT:
+#define NEXT sprev = sbegin; JUMP
+#define JUMP goto *oplabels[*p++]
+
+static void  *oplabels[] = {
+  &&L_OP_FINISH ,        /* matching process terminator (no more alternative) */
+  &&L_OP_END,        /* pattern code terminator (success end) */
+
+  &&L_OP_EXACT1,        /* single byte, N = 1 */
+  &&L_OP_EXACT2,            /* single byte, N = 2 */
+  &&L_OP_EXACT3,            /* single byte, N = 3 */
+  &&L_OP_EXACT4,            /* single byte, N = 4 */
+  &&L_OP_EXACT5,            /* single byte, N = 5 */
+  &&L_OP_EXACTN,            /* single byte */
+  &&L_OP_EXACTMB2N1,        /* mb-length = 2 N = 1 */
+  &&L_OP_EXACTMB2N2,        /* mb-length = 2 N = 2 */
+  &&L_OP_EXACTMB2N3,        /* mb-length = 2 N = 3 */
+  &&L_OP_EXACTMB2N,         /* mb-length = 2 */
+  &&L_OP_EXACTMB3N,         /* mb-length = 3 */
+  &&L_OP_EXACTMBN,          /* other length */
+
+  &&L_OP_EXACT1_IC,         /* single byte, N = 1, ignore case */
+  &&L_OP_EXACTN_IC,         /* single byte,        ignore case */
+
+  &&L_OP_CCLASS,
+  &&L_OP_CCLASS_MB,
+  &&L_OP_CCLASS_MIX,
+  &&L_OP_CCLASS_NOT,
+  &&L_OP_CCLASS_MB_NOT,
+  &&L_OP_CCLASS_MIX_NOT,
+  &&L_OP_CCLASS_NODE,       /* pointer to CClassNode node */
+
+  &&L_OP_ANYCHAR,                 /* "."  */
+  &&L_OP_ANYCHAR_ML,              /* "."  multi-line */
+  &&L_OP_ANYCHAR_STAR,            /* ".*" */
+  &&L_OP_ANYCHAR_ML_STAR,         /* ".*" multi-line */
+  &&L_OP_ANYCHAR_STAR_PEEK_NEXT,
+  &&L_OP_ANYCHAR_ML_STAR_PEEK_NEXT,
+
+  &&L_OP_WORD,
+  &&L_OP_NOT_WORD,
+  &&L_OP_WORD_BOUND,
+  &&L_OP_NOT_WORD_BOUND,
+#ifdef USE_WORD_BEGIN_END
+  &&L_OP_WORD_BEGIN,
+  &&L_OP_WORD_END,
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT,
+#endif
+  &&L_OP_ASCII_WORD,
+  &&L_OP_NOT_ASCII_WORD,
+  &&L_OP_ASCII_WORD_BOUND,
+  &&L_OP_NOT_ASCII_WORD_BOUND,
+#ifdef USE_WORD_BEGIN_END
+  &&L_OP_ASCII_WORD_BEGIN,
+  &&L_OP_ASCII_WORD_END,
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT,
+#endif
+
+  &&L_OP_BEGIN_BUF,
+  &&L_OP_END_BUF,
+  &&L_OP_BEGIN_LINE,
+  &&L_OP_END_LINE,
+  &&L_OP_SEMI_END_BUF,
+  &&L_OP_BEGIN_POSITION,
+  &&L_OP_BEGIN_POS_OR_LINE,   /* used for implicit anchor optimization */
+
+  &&L_OP_BACKREF1,
+  &&L_OP_BACKREF2,
+  &&L_OP_BACKREFN,
+  &&L_OP_BACKREFN_IC,
+  &&L_OP_BACKREF_MULTI,
+  &&L_OP_BACKREF_MULTI_IC,
+#ifdef USE_BACKREF_WITH_LEVEL
+  &&L_OP_BACKREF_WITH_LEVEL,    /* \k<xxx+n>, \k<xxx-n> */
+#else
+  &&L_DEFAULT,
+#endif
+  &&L_OP_MEMORY_START,
+  &&L_OP_MEMORY_START_PUSH,   /* push back-tracker to stack */
+  &&L_OP_MEMORY_END_PUSH,     /* push back-tracker to stack */
+#ifdef USE_SUBEXP_CALL
+  &&L_OP_MEMORY_END_PUSH_REC, /* push back-tracker to stack */
+#else
+  &&L_DEFAULT,
+#endif
+  &&L_OP_MEMORY_END,
+#ifdef USE_SUBEXP_CALL
+  &&L_OP_MEMORY_END_REC,      /* push marker to stack */
+#else
+  &&L_DEFAULT,
+#endif
+
+  &&L_OP_KEEP,
+
+  &&L_OP_FAIL,               /* pop stack and move */
+  &&L_OP_JUMP,
+  &&L_OP_PUSH,
+  &&L_OP_POP,
+  &&L_OP_PUSH_OR_JUMP_EXACT1,  /* if match exact then push, else jump. */
+  &&L_OP_PUSH_IF_PEEK_NEXT,    /* if match exact then push, else none. */
+  &&L_OP_REPEAT,               /* {n,m} */
+  &&L_OP_REPEAT_NG,            /* {n,m}? (non greedy) */
+  &&L_OP_REPEAT_INC,
+  &&L_OP_REPEAT_INC_NG,        /* non greedy */
+  &&L_OP_REPEAT_INC_SG,        /* search and get in stack */
+  &&L_OP_REPEAT_INC_NG_SG,     /* search and get in stack (non greedy) */
+  &&L_OP_NULL_CHECK_START,     /* null loop checker start */
+  &&L_OP_NULL_CHECK_END,       /* null loop checker end   */
+#ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
+  &&L_OP_NULL_CHECK_END_MEMST, /* null loop checker end (with capture status) */
+#else
+  &&L_DEFAULT,
+#endif
+#ifdef USE_SUBEXP_CALL
+  &&L_OP_NULL_CHECK_END_MEMST_PUSH, /* with capture status and push check-end */
+#else
+  &&L_DEFAULT,
+#endif
+
+  &&L_OP_PUSH_POS,             /* (?=...)  start */
+  &&L_OP_POP_POS,              /* (?=...)  end   */
+  &&L_OP_PUSH_POS_NOT,         /* (?!...)  start */
+  &&L_OP_FAIL_POS,             /* (?!...)  end   */
+  &&L_OP_PUSH_STOP_BT,         /* (?>...)  start */
+  &&L_OP_POP_STOP_BT,          /* (?>...)  end   */
+  &&L_OP_LOOK_BEHIND,          /* (?<=...) start (no needs end opcode) */
+  &&L_OP_PUSH_LOOK_BEHIND_NOT, /* (?<!...) start */
+  &&L_OP_FAIL_LOOK_BEHIND_NOT, /* (?<!...) end   */
+
+#ifdef USE_SUBEXP_CALL
+  &&L_OP_CALL,                 /* \g<name> */
+  &&L_OP_RETURN,
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT,  
+#endif
+  &&L_OP_CONDITION,
+
+#ifdef USE_COMBINATION_EXPLOSION_CHECK
+  &&L_OP_STATE_CHECK_PUSH,         /* combination explosion check and push */
+  &&L_OP_STATE_CHECK_PUSH_OR_JUMP, /* check ok -> push, else jump  */
+  &&L_OP_STATE_CHECK,              /* check only */
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT,
+  &&L_DEFAULT,
+#endif
+#ifdef USE_COMBINATION_EXPLOSION_CHECK
+  &&L_OP_STATE_CHECK_ANYCHAR_STAR,
+  &&L_OP_STATE_CHECK_ANYCHAR_ML_STAR,
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT,
+#endif
+  /* no need: IS_DYNAMIC_OPTION() == 0 */
+#if 0   /* no need: IS_DYNAMIC_OPTION() == 0 */
+  &&L_OP_SET_OPTION_PUSH,    /* set option and push recover option */
+  &&L_OP_SET_OPTION          /* set option */
+#else
+  &&L_DEFAULT,
+  &&L_DEFAULT
+#endif
+    };
+#else
+
+#define VM_LOOP                                 \
+  while (1) {                                   \
+  OPCODE_EXEC_HOOK;                             \
+  sbegin = s;                                   \
+  switch (*p++) {
+#define VM_LOOP_END } sprev = sbegin; }
+#define CASE(x) case x:
+#define DEFAULT default:
+#define NEXT break
+#define JUMP continue
+#endif
+
+
+  VM_LOOP {
+    CASE(OP_END)  MOP_IN(OP_END);
       n = s - sstart;
       if (n > best_len) {
 	OnigRegion* region;
@@ -1539,9 +1729,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
       /* default behavior: return first-matching result. */
       goto finish;
-      break;
+      NEXT;
 
-    case OP_EXACT1:  MOP_IN(OP_EXACT1);
+    CASE(OP_EXACT1)  MOP_IN(OP_EXACT1);
 #if 0
       DATA_ENSURE(1);
       if (*p != *s) goto fail;
@@ -1551,9 +1741,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       DATA_ENSURE(0);
       p++;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_EXACT1_IC:  MOP_IN(OP_EXACT1_IC);
+    CASE(OP_EXACT1_IC)  MOP_IN(OP_EXACT1_IC);
       {
 	int len;
 	UChar *q, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
@@ -1573,9 +1763,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_EXACT2:  MOP_IN(OP_EXACT2);
+    CASE(OP_EXACT2)  MOP_IN(OP_EXACT2);
       DATA_ENSURE(2);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1583,10 +1773,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       sprev = s;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACT3:  MOP_IN(OP_EXACT3);
+    CASE(OP_EXACT3)  MOP_IN(OP_EXACT3);
       DATA_ENSURE(3);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1596,10 +1786,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       sprev = s;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACT4:  MOP_IN(OP_EXACT4);
+    CASE(OP_EXACT4)  MOP_IN(OP_EXACT4);
       DATA_ENSURE(4);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1611,10 +1801,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       sprev = s;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACT5:  MOP_IN(OP_EXACT5);
+    CASE(OP_EXACT5)  MOP_IN(OP_EXACT5);
       DATA_ENSURE(5);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1628,10 +1818,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       sprev = s;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTN:  MOP_IN(OP_EXACTN);
+    CASE(OP_EXACTN)  MOP_IN(OP_EXACTN);
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen);
       while (tlen-- > 0) {
@@ -1639,10 +1829,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       sprev = s - 1;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTN_IC:  MOP_IN(OP_EXACTN_IC);
+    CASE(OP_EXACTN_IC)  MOP_IN(OP_EXACTN_IC);
       {
 	int len;
 	UChar *q, *endp, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
@@ -1667,19 +1857,19 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTMB2N1:  MOP_IN(OP_EXACTMB2N1);
+    CASE(OP_EXACTMB2N1)  MOP_IN(OP_EXACTMB2N1);
       DATA_ENSURE(2);
       if (*p != *s) goto fail;
       p++; s++;
       if (*p != *s) goto fail;
       p++; s++;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_EXACTMB2N2:  MOP_IN(OP_EXACTMB2N2);
+    CASE(OP_EXACTMB2N2)  MOP_IN(OP_EXACTMB2N2);
       DATA_ENSURE(4);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1691,10 +1881,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       if (*p != *s) goto fail;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTMB2N3:  MOP_IN(OP_EXACTMB2N3);
+    CASE(OP_EXACTMB2N3)  MOP_IN(OP_EXACTMB2N3);
       DATA_ENSURE(6);
       if (*p != *s) goto fail;
       p++; s++;
@@ -1710,10 +1900,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       if (*p != *s) goto fail;
       p++; s++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTMB2N:  MOP_IN(OP_EXACTMB2N);
+    CASE(OP_EXACTMB2N)  MOP_IN(OP_EXACTMB2N);
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen * 2);
       while (tlen-- > 0) {
@@ -1724,10 +1914,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       sprev = s - 2;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTMB3N:  MOP_IN(OP_EXACTMB3N);
+    CASE(OP_EXACTMB3N)  MOP_IN(OP_EXACTMB3N);
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen * 3);
       while (tlen-- > 0) {
@@ -1740,10 +1930,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       sprev = s - 3;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_EXACTMBN:  MOP_IN(OP_EXACTMBN);
+    CASE(OP_EXACTMBN)  MOP_IN(OP_EXACTMBN);
       GET_LENGTH_INC(tlen,  p);  /* mb-len */
       GET_LENGTH_INC(tlen2, p);  /* string len */
       tlen2 *= tlen;
@@ -1754,18 +1944,18 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       sprev = s - tlen;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_CCLASS:  MOP_IN(OP_CCLASS);
+    CASE(OP_CCLASS)  MOP_IN(OP_CCLASS);
       DATA_ENSURE(1);
       if (BITSET_AT(((BitSetRef )p), *s) == 0) goto fail;
       p += SIZE_BITSET;
       s += enclen(encode, s);   /* OP_CCLASS can match mb-code. \D, \S */
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_MB:  MOP_IN(OP_CCLASS_MB);
+    CASE(OP_CCLASS_MB)  MOP_IN(OP_CCLASS_MB);
       if (! ONIGENC_IS_MBC_HEAD(encode, s)) goto fail;
 
     cclass_mb:
@@ -1792,9 +1982,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       p += tlen;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_MIX:  MOP_IN(OP_CCLASS_MIX);
+    CASE(OP_CCLASS_MIX)  MOP_IN(OP_CCLASS_MIX);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_HEAD(encode, s)) {
 	p += SIZE_BITSET;
@@ -1810,17 +2000,17 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	s++;
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_NOT:  MOP_IN(OP_CCLASS_NOT);
+    CASE(OP_CCLASS_NOT)  MOP_IN(OP_CCLASS_NOT);
       DATA_ENSURE(1);
       if (BITSET_AT(((BitSetRef )p), *s) != 0) goto fail;
       p += SIZE_BITSET;
       s += enclen(encode, s);
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_MB_NOT:  MOP_IN(OP_CCLASS_MB_NOT);
+    CASE(OP_CCLASS_MB_NOT)  MOP_IN(OP_CCLASS_MB_NOT);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_HEAD(encode, s)) {
 	s++;
@@ -1859,9 +2049,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     cc_mb_not_success:
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_MIX_NOT:  MOP_IN(OP_CCLASS_MIX_NOT);
+    CASE(OP_CCLASS_MIX_NOT)  MOP_IN(OP_CCLASS_MIX_NOT);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_HEAD(encode, s)) {
 	p += SIZE_BITSET;
@@ -1877,9 +2067,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	s++;
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_CCLASS_NODE:  MOP_IN(OP_CCLASS_NODE);
+    CASE(OP_CCLASS_NODE)  MOP_IN(OP_CCLASS_NODE);
       {
 	OnigCodePoint code;
         void *node;
@@ -1896,26 +2086,26 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	if (onig_is_code_in_cc_len(mb_len, code, node) == 0) goto fail;
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR:  MOP_IN(OP_ANYCHAR);
+    CASE(OP_ANYCHAR)  MOP_IN(OP_ANYCHAR);
       DATA_ENSURE(1);
       n = enclen(encode, s);
       DATA_ENSURE(n);
       if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0)) goto fail;
       s += n;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR_ML:  MOP_IN(OP_ANYCHAR_ML);
+    CASE(OP_ANYCHAR_ML)  MOP_IN(OP_ANYCHAR_ML);
       DATA_ENSURE(1);
       n = enclen(encode, s);
       DATA_ENSURE(n);
       s += n;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR_STAR:  MOP_IN(OP_ANYCHAR_STAR);
+    CASE(OP_ANYCHAR_STAR)  MOP_IN(OP_ANYCHAR_STAR);
       while (DATA_ENSURE_CHECK1) {
 	STACK_PUSH_ALT(p, s, sprev, pkeep);
 	n = enclen(encode, s);
@@ -1925,9 +2115,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
         s += n;
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR_ML_STAR:  MOP_IN(OP_ANYCHAR_ML_STAR);
+    CASE(OP_ANYCHAR_ML_STAR)  MOP_IN(OP_ANYCHAR_ML_STAR);
       while (DATA_ENSURE_CHECK1) {
 	STACK_PUSH_ALT(p, s, sprev, pkeep);
 	n = enclen(encode, s);
@@ -1942,9 +2132,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR_STAR_PEEK_NEXT:  MOP_IN(OP_ANYCHAR_STAR_PEEK_NEXT);
+    CASE(OP_ANYCHAR_STAR_PEEK_NEXT)  MOP_IN(OP_ANYCHAR_STAR_PEEK_NEXT);
       while (DATA_ENSURE_CHECK1) {
 	if (*p == *s) {
 	  STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
@@ -1957,9 +2147,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       p++;
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ANYCHAR_ML_STAR_PEEK_NEXT:MOP_IN(OP_ANYCHAR_ML_STAR_PEEK_NEXT);
+    CASE(OP_ANYCHAR_ML_STAR_PEEK_NEXT)MOP_IN(OP_ANYCHAR_ML_STAR_PEEK_NEXT);
       while (DATA_ENSURE_CHECK1) {
 	if (*p == *s) {
 	  STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
@@ -1977,10 +2167,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       p++;
       MOP_OUT;
-      break;
+      NEXT;
 
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
-    case OP_STATE_CHECK_ANYCHAR_STAR:  MOP_IN(OP_STATE_CHECK_ANYCHAR_STAR);
+    CASE(OP_STATE_CHECK_ANYCHAR_STAR)  MOP_IN(OP_STATE_CHECK_ANYCHAR_STAR);
       GET_STATE_CHECK_NUM_INC(mem, p);
       while (DATA_ENSURE_CHECK1) {
 	STATE_CHECK_VAL(scv, mem);
@@ -1994,9 +2184,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
         s += n;
       }
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_STATE_CHECK_ANYCHAR_ML_STAR:
+    CASE(OP_STATE_CHECK_ANYCHAR_ML_STAR)
       MOP_IN(OP_STATE_CHECK_ANYCHAR_ML_STAR);
 
       GET_STATE_CHECK_NUM_INC(mem, p);
@@ -2017,46 +2207,46 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      break;
+      NEXT;
 #endif /* USE_COMBINATION_EXPLOSION_CHECK */
 
-    case OP_WORD:  MOP_IN(OP_WORD);
+    CASE(OP_WORD)  MOP_IN(OP_WORD);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_WORD(encode, s, end))
 	goto fail;
 
       s += enclen(encode, s);
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_ASCII_WORD:  MOP_IN(OP_ASCII_WORD);
+    CASE(OP_ASCII_WORD)  MOP_IN(OP_ASCII_WORD);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
 	goto fail;
 
       s += enclen(encode, s);
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_NOT_WORD:  MOP_IN(OP_NOT_WORD);
+    CASE(OP_NOT_WORD)  MOP_IN(OP_NOT_WORD);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_WORD(encode, s, end))
 	goto fail;
 
       s += enclen(encode, s);
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_NOT_ASCII_WORD:  MOP_IN(OP_NOT_ASCII_WORD);
+    CASE(OP_NOT_ASCII_WORD)  MOP_IN(OP_NOT_ASCII_WORD);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
 	goto fail;
 
       s += enclen(encode, s);
       MOP_OUT;
-      break;
+      NEXT;
 
-    case OP_WORD_BOUND:  MOP_IN(OP_WORD_BOUND);
+    CASE(OP_WORD_BOUND)  MOP_IN(OP_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
 	DATA_ENSURE(1);
 	if (! ONIGENC_IS_MBC_WORD(encode, s, end))
@@ -2072,10 +2262,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  goto fail;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_ASCII_WORD_BOUND:  MOP_IN(OP_ASCII_WORD_BOUND);
+    CASE(OP_ASCII_WORD_BOUND)  MOP_IN(OP_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
 	DATA_ENSURE(1);
 	if (! ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
@@ -2091,10 +2281,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  goto fail;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_NOT_WORD_BOUND:  MOP_IN(OP_NOT_WORD_BOUND);
+    CASE(OP_NOT_WORD_BOUND)  MOP_IN(OP_NOT_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
 	if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_WORD(encode, s, end))
 	  goto fail;
@@ -2109,10 +2299,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  goto fail;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_NOT_ASCII_WORD_BOUND:  MOP_IN(OP_NOT_ASCII_WORD_BOUND);
+    CASE(OP_NOT_ASCII_WORD_BOUND)  MOP_IN(OP_NOT_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
 	if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
 	  goto fail;
@@ -2127,73 +2317,73 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  goto fail;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
 #ifdef USE_WORD_BEGIN_END
-    case OP_WORD_BEGIN:  MOP_IN(OP_WORD_BEGIN);
+    CASE(OP_WORD_BEGIN)  MOP_IN(OP_WORD_BEGIN);
       if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_WORD(encode, s, end)) {
 	if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 	}
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_ASCII_WORD_BEGIN:  MOP_IN(OP_ASCII_WORD_BEGIN);
+    CASE(OP_ASCII_WORD_BEGIN)  MOP_IN(OP_ASCII_WORD_BEGIN);
       if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
 	if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 	}
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_WORD_END:  MOP_IN(OP_WORD_END);
+    CASE(OP_WORD_END)  MOP_IN(OP_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
 	if (ON_STR_END(s) || !ONIGENC_IS_MBC_WORD(encode, s, end)) {
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 	}
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_ASCII_WORD_END:  MOP_IN(OP_ASCII_WORD_END);
+    CASE(OP_ASCII_WORD_END)  MOP_IN(OP_ASCII_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
 	if (ON_STR_END(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 	}
       }
       goto fail;
-      break;
+      NEXT;
 #endif
 
-    case OP_BEGIN_BUF:  MOP_IN(OP_BEGIN_BUF);
+    CASE(OP_BEGIN_BUF)  MOP_IN(OP_BEGIN_BUF);
       if (! ON_STR_BEGIN(s)) goto fail;
       if (IS_NOTBOS(msa->options)) goto fail;
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_END_BUF:  MOP_IN(OP_END_BUF);
+    CASE(OP_END_BUF)  MOP_IN(OP_END_BUF);
       if (! ON_STR_END(s)) goto fail;
       if (IS_NOTEOS(msa->options)) goto fail;
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_BEGIN_LINE:  MOP_IN(OP_BEGIN_LINE);
+    CASE(OP_BEGIN_LINE)  MOP_IN(OP_BEGIN_LINE);
     op_begin_line:
       if (ON_STR_BEGIN(s)) {
 	if (IS_NOTBOL(msa->options)) goto fail;
 	MOP_OUT;
-	continue;
+	JUMP;
       }
       else if (ONIGENC_IS_MBC_NEWLINE(encode, sprev, end)
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
@@ -2202,38 +2392,38 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
 		&& !ON_STR_END(s)) {
 	MOP_OUT;
-	continue;
+	JUMP;
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_END_LINE:  MOP_IN(OP_END_LINE);
+    CASE(OP_END_LINE)  MOP_IN(OP_END_LINE);
       if (ON_STR_END(s)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
 	if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
 #endif
 	  if (IS_NOTEOL(msa->options)) goto fail;
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
 	}
 #endif
       }
       else if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 1)) {
 	MOP_OUT;
-	continue;
+	JUMP;
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_SEMI_END_BUF:  MOP_IN(OP_SEMI_END_BUF);
+    CASE(OP_SEMI_END_BUF)  MOP_IN(OP_SEMI_END_BUF);
       if (ON_STR_END(s)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
 	if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
 #endif
 	  if (IS_NOTEOL(msa->options)) goto fail;
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
 	}
 #endif
@@ -2242,7 +2432,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	UChar* ss = s + enclen(encode, s);
 	if (ON_STR_END(ss)) {
 	  MOP_OUT;
-	  continue;
+	  JUMP;
 	}
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
 	else if (IS_NEWLINE_CRLF(option)
@@ -2250,75 +2440,75 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  ss += enclen(encode, ss);
 	  if (ON_STR_END(ss)) {
 	    MOP_OUT;
-	    continue;
+	    JUMP;
 	  }
 	}
 #endif
       }
       goto fail;
-      break;
+      NEXT;
 
-    case OP_BEGIN_POSITION:  MOP_IN(OP_BEGIN_POSITION);
+    CASE(OP_BEGIN_POSITION)  MOP_IN(OP_BEGIN_POSITION);
       if (s != msa->gpos)
 	goto fail;
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_BEGIN_POS_OR_LINE:  MOP_IN(OP_BEGIN_POS_OR_LINE);
+    CASE(OP_BEGIN_POS_OR_LINE)  MOP_IN(OP_BEGIN_POS_OR_LINE);
       if (s != msa->gpos)
 	goto op_begin_line;
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_MEMORY_START_PUSH:  MOP_IN(OP_MEMORY_START_PUSH);
+    CASE(OP_MEMORY_START_PUSH)  MOP_IN(OP_MEMORY_START_PUSH);
       GET_MEMNUM_INC(mem, p);
       STACK_PUSH_MEM_START(mem, s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_MEMORY_START:  MOP_IN(OP_MEMORY_START);
+    CASE(OP_MEMORY_START)  MOP_IN(OP_MEMORY_START);
       GET_MEMNUM_INC(mem, p);
       mem_start_stk[mem] = (OnigStackIndex )((void* )s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_MEMORY_END_PUSH:  MOP_IN(OP_MEMORY_END_PUSH);
+    CASE(OP_MEMORY_END_PUSH)  MOP_IN(OP_MEMORY_END_PUSH);
       GET_MEMNUM_INC(mem, p);
       STACK_PUSH_MEM_END(mem, s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_MEMORY_END:  MOP_IN(OP_MEMORY_END);
+    CASE(OP_MEMORY_END)  MOP_IN(OP_MEMORY_END);
       GET_MEMNUM_INC(mem, p);
       mem_end_stk[mem] = (OnigStackIndex )((void* )s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_KEEP:  MOP_IN(OP_KEEP);
+    CASE(OP_KEEP)  MOP_IN(OP_KEEP);
       pkeep = s;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
 #ifdef USE_SUBEXP_CALL
-    case OP_MEMORY_END_PUSH_REC:  MOP_IN(OP_MEMORY_END_PUSH_REC);
+    CASE(OP_MEMORY_END_PUSH_REC)  MOP_IN(OP_MEMORY_END_PUSH_REC);
       GET_MEMNUM_INC(mem, p);
       STACK_GET_MEM_START(mem, stkp); /* should be before push mem-end. */
       STACK_PUSH_MEM_END(mem, s);
       mem_start_stk[mem] = GET_STACK_INDEX(stkp);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_MEMORY_END_REC:  MOP_IN(OP_MEMORY_END_REC);
+    CASE(OP_MEMORY_END_REC)  MOP_IN(OP_MEMORY_END_REC);
       GET_MEMNUM_INC(mem, p);
       mem_end_stk[mem] = (OnigStackIndex )((void* )s);
       STACK_GET_MEM_START(mem, stkp);
@@ -2330,21 +2520,21 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
       STACK_PUSH_MEM_END_MARK(mem);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif
 
-    case OP_BACKREF1:  MOP_IN(OP_BACKREF1);
+    CASE(OP_BACKREF1)  MOP_IN(OP_BACKREF1);
       mem = 1;
       goto backref;
-      break;
+      NEXT;
 
-    case OP_BACKREF2:  MOP_IN(OP_BACKREF2);
+    CASE(OP_BACKREF2)  MOP_IN(OP_BACKREF2);
       mem = 2;
       goto backref;
-      break;
+      NEXT;
 
-    case OP_BACKREFN:  MOP_IN(OP_BACKREFN);
+    CASE(OP_BACKREFN)  MOP_IN(OP_BACKREFN);
       GET_MEMNUM_INC(mem, p);
     backref:
       {
@@ -2373,11 +2563,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  sprev += len;
 
 	MOP_OUT;
-	continue;
+	JUMP;
       }
-      break;
+      NEXT;
 
-    case OP_BACKREFN_IC:  MOP_IN(OP_BACKREFN_IC);
+    CASE(OP_BACKREFN_IC)  MOP_IN(OP_BACKREFN_IC);
       GET_MEMNUM_INC(mem, p);
       {
 	int len;
@@ -2405,11 +2595,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  sprev += len;
 
 	MOP_OUT;
-	continue;
+	JUMP;
       }
-      break;
+      NEXT;
 
-    case OP_BACKREF_MULTI:  MOP_IN(OP_BACKREF_MULTI);
+    CASE(OP_BACKREF_MULTI)  MOP_IN(OP_BACKREF_MULTI);
       {
 	int len, is_fail;
 	UChar *pstart, *pend, *swork;
@@ -2444,11 +2634,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
 	if (i == tlen) goto fail;
 	MOP_OUT;
-	continue;
+	JUMP;
       }
-      break;
+      NEXT;
 
-    case OP_BACKREF_MULTI_IC:  MOP_IN(OP_BACKREF_MULTI_IC);
+    CASE(OP_BACKREF_MULTI_IC)  MOP_IN(OP_BACKREF_MULTI_IC);
       {
 	int len, is_fail;
 	UChar *pstart, *pend, *swork;
@@ -2483,12 +2673,12 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
 	if (i == tlen) goto fail;
 	MOP_OUT;
-	continue;
+	JUMP;
       }
-      break;
+      NEXT;
 
 #ifdef USE_BACKREF_WITH_LEVEL
-    case OP_BACKREF_WITH_LEVEL:
+    CASE(OP_BACKREF_WITH_LEVEL)
       {
 	int len;
 	OnigOptionType ic;
@@ -2510,36 +2700,36 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  goto fail;
 
 	MOP_OUT;
-	continue;
+	JUMP;
       }
 
-      break;
+    NEXT;
 #endif
 
 #if 0   /* no need: IS_DYNAMIC_OPTION() == 0 */
-    case OP_SET_OPTION_PUSH:  MOP_IN(OP_SET_OPTION_PUSH);
+    CASE(OP_SET_OPTION_PUSH)  MOP_IN(OP_SET_OPTION_PUSH);
       GET_OPTION_INC(option, p);
       STACK_PUSH_ALT(p, s, sprev, pkeep);
       p += SIZE_OP_SET_OPTION + SIZE_OP_FAIL;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_SET_OPTION:  MOP_IN(OP_SET_OPTION);
+    CASE(OP_SET_OPTION)  MOP_IN(OP_SET_OPTION);
       GET_OPTION_INC(option, p);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif
 
-    case OP_NULL_CHECK_START:  MOP_IN(OP_NULL_CHECK_START);
+    CASE(OP_NULL_CHECK_START)  MOP_IN(OP_NULL_CHECK_START);
       GET_MEMNUM_INC(mem, p);    /* mem: null check id */
       STACK_PUSH_NULL_CHECK_START(mem, s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_NULL_CHECK_END:  MOP_IN(OP_NULL_CHECK_END);
+    CASE(OP_NULL_CHECK_END)  MOP_IN(OP_NULL_CHECK_END);
       {
 	int isnull;
 
@@ -2570,11 +2760,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
 #ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
-    case OP_NULL_CHECK_END_MEMST:  MOP_IN(OP_NULL_CHECK_END_MEMST);
+    CASE(OP_NULL_CHECK_END_MEMST)  MOP_IN(OP_NULL_CHECK_END_MEMST);
       {
 	int isnull;
 
@@ -2590,12 +2780,12 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif
 
 #ifdef USE_SUBEXP_CALL
-    case OP_NULL_CHECK_END_MEMST_PUSH:
+    CASE(OP_NULL_CHECK_END_MEMST_PUSH)
       MOP_IN(OP_NULL_CHECK_END_MEMST_PUSH);
       {
 	int isnull;
@@ -2619,27 +2809,27 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif
 
-    case OP_JUMP:  MOP_IN(OP_JUMP);
+    CASE(OP_JUMP)  MOP_IN(OP_JUMP);
       GET_RELADDR_INC(addr, p);
       p += addr;
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_PUSH:  MOP_IN(OP_PUSH);
+    CASE(OP_PUSH)  MOP_IN(OP_PUSH);
       GET_RELADDR_INC(addr, p);
       STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
-    case OP_STATE_CHECK_PUSH:  MOP_IN(OP_STATE_CHECK_PUSH);
+    CASE(OP_STATE_CHECK_PUSH)  MOP_IN(OP_STATE_CHECK_PUSH);
       GET_STATE_CHECK_NUM_INC(mem, p);
       STATE_CHECK_VAL(scv, mem);
       if (scv) goto fail;
@@ -2647,10 +2837,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_RELADDR_INC(addr, p);
       STACK_PUSH_ALT_WITH_STATE_CHECK(p + addr, s, sprev, mem, pkeep);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_STATE_CHECK_PUSH_OR_JUMP:  MOP_IN(OP_STATE_CHECK_PUSH_OR_JUMP);
+    CASE(OP_STATE_CHECK_PUSH_OR_JUMP)  MOP_IN(OP_STATE_CHECK_PUSH_OR_JUMP);
       GET_STATE_CHECK_NUM_INC(mem, p);
       GET_RELADDR_INC(addr, p);
       STATE_CHECK_VAL(scv, mem);
@@ -2661,53 +2851,53 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	STACK_PUSH_ALT_WITH_STATE_CHECK(p + addr, s, sprev, mem, pkeep);
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_STATE_CHECK:  MOP_IN(OP_STATE_CHECK);
+    CASE(OP_STATE_CHECK)  MOP_IN(OP_STATE_CHECK);
       GET_STATE_CHECK_NUM_INC(mem, p);
       STATE_CHECK_VAL(scv, mem);
       if (scv) goto fail;
 
       STACK_PUSH_STATE_CHECK(s, mem);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif /* USE_COMBINATION_EXPLOSION_CHECK */
 
-    case OP_POP:  MOP_IN(OP_POP);
+    CASE(OP_POP)  MOP_IN(OP_POP);
       STACK_POP_ONE;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_PUSH_OR_JUMP_EXACT1:  MOP_IN(OP_PUSH_OR_JUMP_EXACT1);
+    CASE(OP_PUSH_OR_JUMP_EXACT1)  MOP_IN(OP_PUSH_OR_JUMP_EXACT1);
       GET_RELADDR_INC(addr, p);
       if (*p == *s && DATA_ENSURE_CHECK1) {
 	p++;
 	STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
 	MOP_OUT;
-	continue;
+	JUMP;
       }
       p += (addr + 1);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_PUSH_IF_PEEK_NEXT:  MOP_IN(OP_PUSH_IF_PEEK_NEXT);
+    CASE(OP_PUSH_IF_PEEK_NEXT)  MOP_IN(OP_PUSH_IF_PEEK_NEXT);
       GET_RELADDR_INC(addr, p);
       if (*p == *s) {
 	p++;
 	STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
 	MOP_OUT;
-	continue;
+	JUMP;
       }
       p++;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_REPEAT:  MOP_IN(OP_REPEAT);
+    CASE(OP_REPEAT)  MOP_IN(OP_REPEAT);
       {
 	GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
 	GET_RELADDR_INC(addr, p);
@@ -2721,10 +2911,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_REPEAT_NG:  MOP_IN(OP_REPEAT_NG);
+    CASE(OP_REPEAT_NG)  MOP_IN(OP_REPEAT_NG);
       {
 	GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
 	GET_RELADDR_INC(addr, p);
@@ -2739,10 +2929,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_REPEAT_INC:  MOP_IN(OP_REPEAT_INC);
+    CASE(OP_REPEAT_INC)  MOP_IN(OP_REPEAT_INC);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
       si = repeat_stk[mem];
       stkp = STACK_AT(si);
@@ -2762,17 +2952,17 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       STACK_PUSH_REPEAT_INC(si);
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_REPEAT_INC_SG:  MOP_IN(OP_REPEAT_INC_SG);
+    CASE(OP_REPEAT_INC_SG)  MOP_IN(OP_REPEAT_INC_SG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
       STACK_GET_REPEAT(mem, stkp);
       si = GET_STACK_INDEX(stkp);
       goto repeat_inc;
-      break;
+      NEXT;
 
-    case OP_REPEAT_INC_NG:  MOP_IN(OP_REPEAT_INC_NG);
+    CASE(OP_REPEAT_INC_NG)  MOP_IN(OP_REPEAT_INC_NG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
       si = repeat_stk[mem];
       stkp = STACK_AT(si);
@@ -2796,66 +2986,66 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_REPEAT_INC_NG_SG:  MOP_IN(OP_REPEAT_INC_NG_SG);
+    CASE(OP_REPEAT_INC_NG_SG)  MOP_IN(OP_REPEAT_INC_NG_SG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
       STACK_GET_REPEAT(mem, stkp);
       si = GET_STACK_INDEX(stkp);
       goto repeat_inc_ng;
-      break;
+      NEXT;
 
-    case OP_PUSH_POS:  MOP_IN(OP_PUSH_POS);
+    CASE(OP_PUSH_POS)  MOP_IN(OP_PUSH_POS);
       STACK_PUSH_POS(s, sprev, pkeep);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_POP_POS:  MOP_IN(OP_POP_POS);
+    CASE(OP_POP_POS)  MOP_IN(OP_POP_POS);
       {
 	STACK_POS_END(stkp);
 	s     = stkp->u.state.pstr;
 	sprev = stkp->u.state.pstr_prev;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_PUSH_POS_NOT:  MOP_IN(OP_PUSH_POS_NOT);
+    CASE(OP_PUSH_POS_NOT)  MOP_IN(OP_PUSH_POS_NOT);
       GET_RELADDR_INC(addr, p);
       STACK_PUSH_POS_NOT(p + addr, s, sprev, pkeep);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_FAIL_POS:  MOP_IN(OP_FAIL_POS);
+    CASE(OP_FAIL_POS)  MOP_IN(OP_FAIL_POS);
       STACK_POP_TIL_POS_NOT;
       goto fail;
-      break;
+      NEXT;
 
-    case OP_PUSH_STOP_BT:  MOP_IN(OP_PUSH_STOP_BT);
+    CASE(OP_PUSH_STOP_BT)  MOP_IN(OP_PUSH_STOP_BT);
       STACK_PUSH_STOP_BT;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_POP_STOP_BT:  MOP_IN(OP_POP_STOP_BT);
+    CASE(OP_POP_STOP_BT)  MOP_IN(OP_POP_STOP_BT);
       STACK_STOP_BT_END;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_LOOK_BEHIND:  MOP_IN(OP_LOOK_BEHIND);
+    CASE(OP_LOOK_BEHIND)  MOP_IN(OP_LOOK_BEHIND);
       GET_LENGTH_INC(tlen, p);
       s = (UChar* )ONIGENC_STEP_BACK(encode, str, s, (int )tlen);
       if (IS_NULL(s)) goto fail;
       sprev = (UChar* )onigenc_get_prev_char_head(encode, str, s);
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_PUSH_LOOK_BEHIND_NOT:  MOP_IN(OP_PUSH_LOOK_BEHIND_NOT);
+    CASE(OP_PUSH_LOOK_BEHIND_NOT)  MOP_IN(OP_PUSH_LOOK_BEHIND_NOT);
       GET_RELADDR_INC(addr, p);
       GET_LENGTH_INC(tlen, p);
       q = (UChar* )ONIGENC_STEP_BACK(encode, str, s, (int )tlen);
@@ -2871,32 +3061,32 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	sprev = (UChar* )onigenc_get_prev_char_head(encode, str, s);
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_FAIL_LOOK_BEHIND_NOT:  MOP_IN(OP_FAIL_LOOK_BEHIND_NOT);
+    CASE(OP_FAIL_LOOK_BEHIND_NOT)  MOP_IN(OP_FAIL_LOOK_BEHIND_NOT);
       STACK_POP_TIL_LOOK_BEHIND_NOT;
       goto fail;
-      break;
+      NEXT;
 
 #ifdef USE_SUBEXP_CALL
-    case OP_CALL:  MOP_IN(OP_CALL);
+    CASE(OP_CALL)  MOP_IN(OP_CALL);
       GET_ABSADDR_INC(addr, p);
       STACK_PUSH_CALL_FRAME(p);
       p = reg->p + addr;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_RETURN:  MOP_IN(OP_RETURN);
+    CASE(OP_RETURN)  MOP_IN(OP_RETURN);
       STACK_RETURN(p);
       STACK_PUSH_RETURN;
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 #endif
 
-    case OP_CONDITION:  MOP_IN(OP_CONDITION);
+    CASE(OP_CONDITION)  MOP_IN(OP_CONDITION);
       GET_MEMNUM_INC(mem, p);
       GET_RELADDR_INC(addr, p);
       if ((mem > num_mem) ||
@@ -2905,17 +3095,17 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	p += addr;
       }
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    case OP_FINISH:
+    CASE(OP_FINISH)
       goto finish;
-      break;
+      NEXT;
 
     fail:
       MOP_OUT;
       /* fall */
-    case OP_FAIL:  MOP_IN(OP_FAIL);
+    CASE(OP_FAIL)  MOP_IN(OP_FAIL);
       STACK_POP;
       p     = stk->u.state.pcode;
       s     = stk->u.state.pstr;
@@ -2930,15 +3120,12 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
 
       MOP_OUT;
-      continue;
-      break;
+      JUMP;
+      NEXT;
 
-    default:
+    DEFAULT
       goto bytecode_error;
-
-    } /* end of switch */
-    sprev = sbegin;
-  } /* end of while(1) */
+  } VM_LOOP_END
 
  finish:
   STACK_SAVE;

--- a/regexec.c
+++ b/regexec.c
@@ -1436,7 +1436,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #ifdef USE_DIRECT_THREADED_VM
 #define VM_LOOP JUMP;
 #define VM_LOOP_END
-#define CASE(x) L_##x: OPCODE_EXEC_HOOK;
+#define CASE(x) L_##x: sbegin = s; OPCODE_EXEC_HOOK;
 #define DEFAULT L_DEFAULT:
 #define NEXT sprev = sbegin; JUMP
 #define JUMP goto *oplabels[*p++]

--- a/regexec.c
+++ b/regexec.c
@@ -1433,7 +1433,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
 
 
-#ifdef USE_DIRECT_THREADED_VM
+#if USE_DIRECT_THREADED_VM
 #define VM_LOOP JUMP;
 #define VM_LOOP_END
 #define CASE(x) L_##x: sbegin = s; OPCODE_EXEC_HOOK;
@@ -1615,7 +1615,7 @@ static void  *oplabels[] = {
 #define CASE(x) case x:
 #define DEFAULT default:
 #define NEXT break
-#define JUMP continue
+#define JUMP continue; break
 #endif
 
 
@@ -1774,7 +1774,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACT3)  MOP_IN(OP_EXACT3);
       DATA_ENSURE(3);
@@ -1787,7 +1786,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACT4)  MOP_IN(OP_EXACT4);
       DATA_ENSURE(4);
@@ -1802,7 +1800,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACT5)  MOP_IN(OP_EXACT5);
       DATA_ENSURE(5);
@@ -1819,7 +1816,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTN)  MOP_IN(OP_EXACTN);
       GET_LENGTH_INC(tlen, p);
@@ -1830,7 +1826,6 @@ static void  *oplabels[] = {
       sprev = s - 1;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTN_IC)  MOP_IN(OP_EXACTN_IC);
       {
@@ -1858,7 +1853,6 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTMB2N1)  MOP_IN(OP_EXACTMB2N1);
       DATA_ENSURE(2);
@@ -1882,7 +1876,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTMB2N3)  MOP_IN(OP_EXACTMB2N3);
       DATA_ENSURE(6);
@@ -1901,7 +1894,6 @@ static void  *oplabels[] = {
       p++; s++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTMB2N)  MOP_IN(OP_EXACTMB2N);
       GET_LENGTH_INC(tlen, p);
@@ -1915,7 +1907,6 @@ static void  *oplabels[] = {
       sprev = s - 2;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTMB3N)  MOP_IN(OP_EXACTMB3N);
       GET_LENGTH_INC(tlen, p);
@@ -1931,7 +1922,6 @@ static void  *oplabels[] = {
       sprev = s - 3;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_EXACTMBN)  MOP_IN(OP_EXACTMBN);
       GET_LENGTH_INC(tlen,  p);  /* mb-len */
@@ -1945,7 +1935,6 @@ static void  *oplabels[] = {
       sprev = s - tlen;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_CCLASS)  MOP_IN(OP_CCLASS);
       DATA_ENSURE(1);
@@ -2263,7 +2252,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_ASCII_WORD_BOUND)  MOP_IN(OP_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
@@ -2282,7 +2270,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_NOT_WORD_BOUND)  MOP_IN(OP_NOT_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
@@ -2300,7 +2287,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_NOT_ASCII_WORD_BOUND)  MOP_IN(OP_NOT_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
@@ -2318,7 +2304,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
 #ifdef USE_WORD_BEGIN_END
     CASE(OP_WORD_BEGIN)  MOP_IN(OP_WORD_BEGIN);
@@ -2368,7 +2353,6 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_END_BUF)  MOP_IN(OP_END_BUF);
       if (! ON_STR_END(s)) goto fail;
@@ -2376,7 +2360,6 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_BEGIN_LINE)  MOP_IN(OP_BEGIN_LINE);
     op_begin_line:
@@ -2454,7 +2437,6 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_BEGIN_POS_OR_LINE)  MOP_IN(OP_BEGIN_POS_OR_LINE);
       if (s != msa->gpos)
@@ -2462,41 +2444,35 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_MEMORY_START_PUSH)  MOP_IN(OP_MEMORY_START_PUSH);
       GET_MEMNUM_INC(mem, p);
       STACK_PUSH_MEM_START(mem, s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_MEMORY_START)  MOP_IN(OP_MEMORY_START);
       GET_MEMNUM_INC(mem, p);
       mem_start_stk[mem] = (OnigStackIndex )((void* )s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_MEMORY_END_PUSH)  MOP_IN(OP_MEMORY_END_PUSH);
       GET_MEMNUM_INC(mem, p);
       STACK_PUSH_MEM_END(mem, s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_MEMORY_END)  MOP_IN(OP_MEMORY_END);
       GET_MEMNUM_INC(mem, p);
       mem_end_stk[mem] = (OnigStackIndex )((void* )s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_KEEP)  MOP_IN(OP_KEEP);
       pkeep = s;
       MOP_OUT;
       JUMP;
-      NEXT;
 
 #ifdef USE_SUBEXP_CALL
     CASE(OP_MEMORY_END_PUSH_REC)  MOP_IN(OP_MEMORY_END_PUSH_REC);
@@ -2506,7 +2482,6 @@ static void  *oplabels[] = {
       mem_start_stk[mem] = GET_STACK_INDEX(stkp);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_MEMORY_END_REC)  MOP_IN(OP_MEMORY_END_REC);
       GET_MEMNUM_INC(mem, p);
@@ -2521,7 +2496,6 @@ static void  *oplabels[] = {
       STACK_PUSH_MEM_END_MARK(mem);
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif
 
     CASE(OP_BACKREF1)  MOP_IN(OP_BACKREF1);
@@ -2565,7 +2539,6 @@ static void  *oplabels[] = {
 	MOP_OUT;
 	JUMP;
       }
-      NEXT;
 
     CASE(OP_BACKREFN_IC)  MOP_IN(OP_BACKREFN_IC);
       GET_MEMNUM_INC(mem, p);
@@ -2675,7 +2648,6 @@ static void  *oplabels[] = {
 	MOP_OUT;
 	JUMP;
       }
-      NEXT;
 
 #ifdef USE_BACKREF_WITH_LEVEL
     CASE(OP_BACKREF_WITH_LEVEL)
@@ -2703,7 +2675,6 @@ static void  *oplabels[] = {
 	JUMP;
       }
 
-    NEXT;
 #endif
 
 #if 0   /* no need: IS_DYNAMIC_OPTION() == 0 */
@@ -2713,13 +2684,11 @@ static void  *oplabels[] = {
       p += SIZE_OP_SET_OPTION + SIZE_OP_FAIL;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_SET_OPTION)  MOP_IN(OP_SET_OPTION);
       GET_OPTION_INC(option, p);
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif
 
     CASE(OP_NULL_CHECK_START)  MOP_IN(OP_NULL_CHECK_START);
@@ -2727,7 +2696,6 @@ static void  *oplabels[] = {
       STACK_PUSH_NULL_CHECK_START(mem, s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_NULL_CHECK_END)  MOP_IN(OP_NULL_CHECK_END);
       {
@@ -2761,7 +2729,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
 #ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
     CASE(OP_NULL_CHECK_END_MEMST)  MOP_IN(OP_NULL_CHECK_END_MEMST);
@@ -2781,7 +2748,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif
 
 #ifdef USE_SUBEXP_CALL
@@ -2810,7 +2776,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif
 
     CASE(OP_JUMP)  MOP_IN(OP_JUMP);
@@ -2819,14 +2784,12 @@ static void  *oplabels[] = {
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
       JUMP;
-      NEXT;
 
     CASE(OP_PUSH)  MOP_IN(OP_PUSH);
       GET_RELADDR_INC(addr, p);
       STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
       MOP_OUT;
       JUMP;
-      NEXT;
 
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
     CASE(OP_STATE_CHECK_PUSH)  MOP_IN(OP_STATE_CHECK_PUSH);
@@ -2838,7 +2801,6 @@ static void  *oplabels[] = {
       STACK_PUSH_ALT_WITH_STATE_CHECK(p + addr, s, sprev, mem, pkeep);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_STATE_CHECK_PUSH_OR_JUMP)  MOP_IN(OP_STATE_CHECK_PUSH_OR_JUMP);
       GET_STATE_CHECK_NUM_INC(mem, p);
@@ -2852,7 +2814,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_STATE_CHECK)  MOP_IN(OP_STATE_CHECK);
       GET_STATE_CHECK_NUM_INC(mem, p);
@@ -2862,14 +2823,12 @@ static void  *oplabels[] = {
       STACK_PUSH_STATE_CHECK(s, mem);
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif /* USE_COMBINATION_EXPLOSION_CHECK */
 
     CASE(OP_POP)  MOP_IN(OP_POP);
       STACK_POP_ONE;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_PUSH_OR_JUMP_EXACT1)  MOP_IN(OP_PUSH_OR_JUMP_EXACT1);
       GET_RELADDR_INC(addr, p);
@@ -2882,7 +2841,6 @@ static void  *oplabels[] = {
       p += (addr + 1);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_PUSH_IF_PEEK_NEXT)  MOP_IN(OP_PUSH_IF_PEEK_NEXT);
       GET_RELADDR_INC(addr, p);
@@ -2895,7 +2853,6 @@ static void  *oplabels[] = {
       p++;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_REPEAT)  MOP_IN(OP_REPEAT);
       {
@@ -2912,7 +2869,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_REPEAT_NG)  MOP_IN(OP_REPEAT_NG);
       {
@@ -2930,7 +2886,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_REPEAT_INC)  MOP_IN(OP_REPEAT_INC);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
@@ -2953,7 +2908,6 @@ static void  *oplabels[] = {
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
       JUMP;
-      NEXT;
 
     CASE(OP_REPEAT_INC_SG)  MOP_IN(OP_REPEAT_INC_SG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
@@ -2987,7 +2941,6 @@ static void  *oplabels[] = {
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
       JUMP;
-      NEXT;
 
     CASE(OP_REPEAT_INC_NG_SG)  MOP_IN(OP_REPEAT_INC_NG_SG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
@@ -3000,7 +2953,6 @@ static void  *oplabels[] = {
       STACK_PUSH_POS(s, sprev, pkeep);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_POP_POS)  MOP_IN(OP_POP_POS);
       {
@@ -3010,14 +2962,12 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_PUSH_POS_NOT)  MOP_IN(OP_PUSH_POS_NOT);
       GET_RELADDR_INC(addr, p);
       STACK_PUSH_POS_NOT(p + addr, s, sprev, pkeep);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_FAIL_POS)  MOP_IN(OP_FAIL_POS);
       STACK_POP_TIL_POS_NOT;
@@ -3028,13 +2978,11 @@ static void  *oplabels[] = {
       STACK_PUSH_STOP_BT;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_POP_STOP_BT)  MOP_IN(OP_POP_STOP_BT);
       STACK_STOP_BT_END;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_LOOK_BEHIND)  MOP_IN(OP_LOOK_BEHIND);
       GET_LENGTH_INC(tlen, p);
@@ -3043,7 +2991,6 @@ static void  *oplabels[] = {
       sprev = (UChar* )onigenc_get_prev_char_head(encode, str, s);
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_PUSH_LOOK_BEHIND_NOT)  MOP_IN(OP_PUSH_LOOK_BEHIND_NOT);
       GET_RELADDR_INC(addr, p);
@@ -3062,7 +3009,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_FAIL_LOOK_BEHIND_NOT)  MOP_IN(OP_FAIL_LOOK_BEHIND_NOT);
       STACK_POP_TIL_LOOK_BEHIND_NOT;
@@ -3076,14 +3022,12 @@ static void  *oplabels[] = {
       p = reg->p + addr;
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_RETURN)  MOP_IN(OP_RETURN);
       STACK_RETURN(p);
       STACK_PUSH_RETURN;
       MOP_OUT;
       JUMP;
-      NEXT;
 #endif
 
     CASE(OP_CONDITION)  MOP_IN(OP_CONDITION);
@@ -3096,7 +3040,6 @@ static void  *oplabels[] = {
       }
       MOP_OUT;
       JUMP;
-      NEXT;
 
     CASE(OP_FINISH)
       goto finish;
@@ -3121,7 +3064,6 @@ static void  *oplabels[] = {
 
       MOP_OUT;
       JUMP;
-      NEXT;
 
     DEFAULT
       goto bytecode_error;


### PR DESCRIPTION
Here are benchmark scores. Benchmark suite is derived form http://sljit.sourceforge.net/regex_perf.html.

<table>
    <tr><td></td><td>Master</td><td>This PR</td><td>Improve Rate</td></tr>
    <tr><td class="pattern">Twain</td><td class="time">47 ms</td><td class="time">47 ms</td><td>0%</td></tr>
    <tr><td class="pattern">^Twain</td><td class="time">47 ms</td><td class="time">47 ms</td><td>0%</td></tr>
    <tr><td class="pattern">Twain$</td><td class="time">47 ms</td><td class="time">47 ms</td><td>0%</td></tr>
    <tr><td class="pattern">Huck[a-zA-Z]+|Finn[a-zA-Z]+</td><td class="time">127 ms</td><td class="time">127 ms</td><td>0%</td></tr>
    <tr><td class="pattern">a[^x]{20}b</td><td class="time">1172 ms</td><td class="time">889 ms</td><td>31%</td></tr>
    <tr><td class="pattern">Tom|Sawyer|Huckleberry|Finn</td><td class="time">151 ms</td><td class="time">153 ms</td><td>-1%</td></tr>
    <tr><td class="pattern">.{0,3}(Tom|Sawyer|Huckleberry|Finn)</td><td class="time">497 ms</td><td class="time">449 ms</td><td>10%</td></tr>
    <tr><td class="pattern">[a-zA-Z]+ing</td><td class="time">4032 ms</td><td class="time">2705 ms</td><td>49%</td></tr>
    <tr><td class="pattern">^[a-zA-Z]{0,4}ing[^a-zA-Z]</td><td class="time">96 ms</td><td class="time">98 ms</td><td>-2%</td></tr>
    <tr><td class="pattern">[a-zA-Z]+ing$</td><td class="time">4175 ms</td><td class="time">2797 ms</td><td>49%</td></tr>
    <tr><td class="pattern">^[a-zA-Z ]{5,}$</td><td class="time">1770 ms</td><td class="time">1623 ms</td><td>9%</td></tr>
    <tr><td class="pattern">^.{16,20}$</td><td class="time">1757 ms</td><td class="time">1637 ms</td><td>7%</td></tr>
    <tr><td class="pattern">([a-f](.[d-m].){0,2}[h-n]){2}</td><td class="time">1849 ms</td><td class="time">1670 ms</td><td>11%</td></tr>
    <tr><td class="pattern">([A-Za-z]awyer|[A-Za-z]inn)[^a-zA-Z]</td><td class="time">656 ms</td><td class="time">607 ms</td><td>8%</td></tr>
    <tr><td class="pattern">"[^"]{0,30}[?!\.]"</td><td class="time">115 ms</td><td class="time">93 ms</td><td>24%</td></tr>
    <tr><td class="pattern">Tom.{10,25}river|river.{10,25}Tom</td><td class="time">260 ms</td><td class="time">262 ms</td><td>-1%</td></tr>
</table>

Env:
```
$ uname -a
Linux Dynabook 3.19.0-18-generic #18-Ubuntu SMP Tue May 19 18:31:35 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

$ cat /proc/cpuinfo
processor	: 0
vendor_id	: GenuineIntel
cpu family	: 6
model		: 37
model name	: Intel(R) Core(TM) i5 CPU       M 450  @ 2.40GHz
stepping	: 5
microcode	: 0x2
cpu MHz		: 1199.000
cache size	: 3072 KB
physical id	: 0
siblings	: 4
core id		: 0
cpu cores	: 2
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 11
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts nopl xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 popcnt lahf_lm ida arat dtherm tpr_shadow vnmi flexpriority ept vpid
bugs		:
bogomips	: 4788.65
clflush size	: 64
cache_alignment	: 64
address sizes	: 36 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: GenuineIntel
cpu family	: 6
model		: 37
model name	: Intel(R) Core(TM) i5 CPU       M 450  @ 2.40GHz
stepping	: 5
microcode	: 0x2
cpu MHz		: 1199.000
cache size	: 3072 KB
physical id	: 0
siblings	: 4
core id		: 0
cpu cores	: 2
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 11
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts nopl xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 popcnt lahf_lm ida arat dtherm tpr_shadow vnmi flexpriority ept vpid
bugs		:
bogomips	: 4788.65
clflush size	: 64
cache_alignment	: 64
address sizes	: 36 bits physical, 48 bits virtual
power management:

processor	: 2
vendor_id	: GenuineIntel
cpu family	: 6
model		: 37
model name	: Intel(R) Core(TM) i5 CPU       M 450  @ 2.40GHz
stepping	: 5
microcode	: 0x2
cpu MHz		: 2133.000
cache size	: 3072 KB
physical id	: 0
siblings	: 4
core id		: 2
cpu cores	: 2
apicid		: 4
initial apicid	: 4
fpu		: yes
fpu_exception	: yes
cpuid level	: 11
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts nopl xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 popcnt lahf_lm ida arat dtherm tpr_shadow vnmi flexpriority ept vpid
bugs		:
bogomips	: 4788.65
clflush size	: 64
cache_alignment	: 64
address sizes	: 36 bits physical, 48 bits virtual
power management:

processor	: 3
vendor_id	: GenuineIntel
cpu family	: 6
model		: 37
model name	: Intel(R) Core(TM) i5 CPU       M 450  @ 2.40GHz
stepping	: 5
microcode	: 0x2
cpu MHz		: 1199.000
cache size	: 3072 KB
physical id	: 0
siblings	: 4
core id		: 2
cpu cores	: 2
apicid		: 5
initial apicid	: 5
fpu		: yes
fpu_exception	: yes
cpuid level	: 11
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts nopl xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 popcnt lahf_lm ida arat dtherm tpr_shadow vnmi flexpriority ept vpid
bugs		:
bogomips	: 4788.65
clflush size	: 64
cache_alignment	: 64
address sizes	: 36 bits physical, 48 bits virtual
power management:

$ cat /proc/meminfo
MemTotal:        7965524 kB
MemFree:         6007232 kB
MemAvailable:    6635616 kB
Buffers:          147344 kB
Cached:           791320 kB
SwapCached:            0 kB
Active:          1170092 kB
Inactive:         614612 kB
Active(anon):     848752 kB
Inactive(anon):   164980 kB
Active(file):     321340 kB
Inactive(file):   449632 kB
Unevictable:          64 kB
Mlocked:              64 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:               856 kB
Writeback:             0 kB
AnonPages:        846212 kB
Mapped:           257944 kB
Shmem:            167692 kB
Slab:              81000 kB
SReclaimable:      52676 kB
SUnreclaim:        28324 kB
KernelStack:        7824 kB
PageTables:        27924 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     3982760 kB
Committed_AS:    4154020 kB
VmallocTotal:   34359738367 kB
VmallocUsed:      551880 kB
VmallocChunk:   34359178716 kB
HardwareCorrupted:     0 kB
AnonHugePages:    327680 kB
CmaTotal:              0 kB
CmaFree:               0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
DirectMap4k:       99392 kB
DirectMap2M:     8079360 kB

$ gcc --version
gcc (Ubuntu 4.9.2-10ubuntu13) 4.9.2
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

```