### PR TITLE
Support --enable-mutlithread for MinGW build

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -97,12 +97,20 @@ AC_ARG_ENABLE(multithread,
 	[  --enable-multithread    enable multithread support],
 	[multithread=$enableval])
 if test "${multithread}" = yes; then
-  dnl This check must be after AC_PROG_CC.
-  AC_CHECK_HEADERS(pthread.h,
-	[AC_DEFINE(USE_MULTI_THREAD_SYSTEM,1,[Define if enbale multithread support])
-	 AC_DEFINE(USE_DEFAULT_MULTI_THREAD_SYSTEM,1,[Define if enable the default multithread system])
-  ])
-  AC_CHECK_LIB(pthread, pthread_mutex_init)
+  case $host_os in
+  mingw*)
+    AC_DEFINE(USE_MULTI_THREAD_SYSTEM,1,[Define if enbale multithread support])
+    AC_DEFINE(USE_DEFAULT_MULTI_THREAD_SYSTEM,1,[Define if enable the default multithread system])
+    ;;
+  *)
+    dnl This check must be after AC_PROG_CC.
+    AC_CHECK_HEADERS(pthread.h,
+	  [AC_DEFINE(USE_MULTI_THREAD_SYSTEM,1,[Define if enbale multithread support])
+	   AC_DEFINE(USE_DEFAULT_MULTI_THREAD_SYSTEM,1,[Define if enable the default multithread system])
+    ])
+    AC_CHECK_LIB(pthread, pthread_mutex_init)
+    ;;
+  esac
 fi
 
 


### PR DESCRIPTION
We don't need to check pthread availability for MinGW build because
Windows provides thread API by default.

Note that we need to regenerate `configure`.