### PR TITLE
Fix build error on systems using BSD make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ do_subst = sed                                          \
       -e 's,[@]includedir[@],$(includedir),g'
 
 oniguruma.pc: $(srcdir)/oniguruma.pc.in Makefile
-	$(do_subst) < $(<) > $(@)
+	$(do_subst) < $(srcdir)/oniguruma.pc.in > $(@)
 
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = oniguruma.pc

--- a/Makefile.in
+++ b/Makefile.in
@@ -1428,7 +1428,7 @@ uninstall-am: uninstall-binSCRIPTS uninstall-includeHEADERS \
 onig-config: onig-config.in
 
 oniguruma.pc: $(srcdir)/oniguruma.pc.in Makefile
-	$(do_subst) < $(<) > $(@)
+	$(do_subst) < $(srcdir)/oniguruma.pc.in > $(@)
 
 dll:
 	$(CXX) -shared -Wl,--output-def,libonig.def -o libonig.dll *.o \


### PR DESCRIPTION
The line below causes build error on systems using BSD make (FreeBSD, NetBSD, etc.), since BSD make substitutes `$<` with an empty string if more than one file is specified as the dependency.

```
oniguruma.pc: $(srcdir)/oniguruma.pc.in Makefile
	$(do_subst) < $(<) > $(@)
```

This PR fixes the issue by hard-coding the first argument in place of `$<`.