### PR TITLE
raise error if error code is set

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -2784,6 +2784,7 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
       name_end = end;
     }
 
+    if (r) goto err;
     if (is_num != 0) {
       *rback_num = onig_scan_unsigned_number(&pnum_head, name_end, enc);
       if (*rback_num < 0) return ONIGERR_TOO_BIG_NUMBER;


### PR DESCRIPTION
But ruby considers it is spec at r53610.
(though it may change)
