### PR TITLE
Suppress warnings [-Wpointer-sign]

### DIFF
--- a/sample/crnl.c
+++ b/sample/crnl.c
@@ -45,7 +45,7 @@ x0(int no, char* pattern_arg, char* str_arg,
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	ONIG_OPTION_NEWLINE_CRLF, ONIG_ENCODING_UTF8, ONIG_SYNTAX_DEFAULT, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -70,7 +70,7 @@ x0(int no, char* pattern_arg, char* str_arg,
     result(no, r, -1, expected_from, expected_to);
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;

--- a/sample/encode.c
+++ b/sample/encode.c
@@ -30,7 +30,7 @@ search(regex_t* reg, unsigned char* str, unsigned char* end)
             ONIGENC_NAME(onig_get_encoding(reg)));
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     fprintf(stderr, "ERROR: %s\n", s);
     fprintf(stderr, "  (%s)\n", ONIGENC_NAME(onig_get_encoding(reg)));
@@ -56,7 +56,7 @@ exec(OnigEncoding enc, OnigOptionType options,
                pattern + onigenc_str_bytelen_null(enc, pattern),
                options, enc, ONIG_SYNTAX_DEFAULT, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -103,7 +103,7 @@ exec_deluxe(OnigEncoding pattern_enc, OnigEncoding str_enc,
                       pattern + onigenc_str_bytelen_null(pattern_enc, pattern),
                       &ci, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;

--- a/sample/listcap.c
+++ b/sample/listcap.c
@@ -36,7 +36,7 @@ extern int ex(unsigned char* str, unsigned char* pattern,
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	       ONIG_OPTION_DEFAULT, ONIG_ENCODING_ASCII, syntax, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -68,7 +68,7 @@ extern int ex(unsigned char* str, unsigned char* pattern,
     fprintf(stderr, "search fail\n");
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     return -1;
   }

--- a/sample/names.c
+++ b/sample/names.c
@@ -38,7 +38,7 @@ extern int main(int argc, char* argv[])
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	ONIG_OPTION_DEFAULT, ONIG_ENCODING_ASCII, ONIG_SYNTAX_DEFAULT, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -61,7 +61,7 @@ extern int main(int argc, char* argv[])
     r = -1;
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     return -1;
   }

--- a/sample/simple.c
+++ b/sample/simple.c
@@ -19,7 +19,7 @@ extern int main(int argc, char* argv[])
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	ONIG_OPTION_DEFAULT, ONIG_ENCODING_ASCII, ONIG_SYNTAX_DEFAULT, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -45,7 +45,7 @@ extern int main(int argc, char* argv[])
     r = -1;
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;

--- a/sample/sql.c
+++ b/sample/sql.c
@@ -36,7 +36,7 @@ extern int main(int argc, char* argv[])
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	       ONIG_OPTION_DEFAULT, ONIG_ENCODING_ASCII, &SQLSyntax, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -62,7 +62,7 @@ extern int main(int argc, char* argv[])
     r = -1;
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;

--- a/sample/syntax.c
+++ b/sample/syntax.c
@@ -19,7 +19,7 @@ extern int exec(OnigSyntaxType* syntax,
   r = onig_new(&reg, pattern, pattern + strlen((char* )pattern),
 	       ONIG_OPTION_DEFAULT, ONIG_ENCODING_ASCII, syntax, &einfo);
   if (r != ONIG_NORMAL) {
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r, &einfo);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;
@@ -45,7 +45,7 @@ extern int exec(OnigSyntaxType* syntax,
     r = -1;
   }
   else { /* error */
-    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
     onig_error_code_to_str(s, r);
     fprintf(stderr, "ERROR: %s\n", s);
     return -1;


### PR DESCRIPTION
Fix these warning.

```
names.c:42:28: warning: passing 'char [90]' to parameter of type 'OnigUChar *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
    onig_error_code_to_str(s, r, &einfo);
                           ^
../oniguruma.h:760:44: note: passing argument to parameter 's' here
int onig_error_code_to_str PV_((OnigUChar* s, OnigPosition err_code, ...));
```

These warning found by [-Wpointer-sign] option on clang.