### PR TITLE
Define PRIdPTRDIFF at regint.h if not defined yet

### DIFF
--- a/regint.h
+++ b/regint.h
@@ -264,15 +264,17 @@ typedef unsigned int uintptr_t;
 #ifndef PRIdPTR
 # ifdef _WIN64
 #  define PRIdPTR	"I64d"
-#  define PRIdPTRDIFF	"I64d"
 #  define PRIuPTR	"I64u"
 #  define PRIxPTR	"I64x"
 # else
 #  define PRIdPTR	"ld"
-#  define PRIdPTRDIFF	"ld"
 #  define PRIuPTR	"lu"
 #  define PRIxPTR	"lx"
 # endif
+#endif
+
+#ifndef PRIdPTRDIFF
+# define PRIdPTRDIFF PRIdPTR
 #endif
 
 #include "regenc.h"


### PR DESCRIPTION
Motivation:

Because PRIdPTRDIFF is not defined on OSX with default c compiler, cannot build onigumo with ONIG_DEBUG_COMPILE=1.
```sh
$ cd Onigumo
$ ./configure CFLAGS="-DONIG_DEBUG_COMPILE=1"
$ make

/bin/sh ./libtool --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -I.. -I/usr/local/include -I../enc/unicode  -Wall -DONIG_DEBUG_COMPILE=1 -MT regexec.lo -MD -MP -MF .deps/regexec.Tpo -c -o regexec.lo ../regexec.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I.. -I/usr/local/include -I../enc/unicode -Wall -DONIG_DEBUG_COMPILE=1 -MT regexec.lo -MD -MP -MF .deps/regexec.Tpo -c ../regexec.c  -fno-common -DPIC -o .libs/regexec.o
../regexec.c:4412:43: error: expected ')'
    fprintf(stderr, "onig_search: error %"PRIdPTRDIFF"\n", r);
                                          ^
../regexec.c:4412:12: note: to match this '('
    fprintf(stderr, "onig_search: error %"PRIdPTRDIFF"\n", r);
           ^
../regexec.c:4421:43: error: expected ')'
    fprintf(stderr, "onig_search: error %"PRIdPTRDIFF"\n", r);
                                          ^
../regexec.c:4421:12: note: to match this '('
    fprintf(stderr, "onig_search: error %"PRIdPTRDIFF"\n", r);
           ^
2 errors generated.
```

Modifications:

- Define PRIdPTRDIFF

Result:

No more build error