### PR TITLE
CRuby enc/*.c needs other way to detect

### DIFF
--- a/regenc.h
+++ b/regenc.h
@@ -30,6 +30,9 @@
  * SUCH DAMAGE.
  */
 
+#if !defined(RUBY) && (defined(RUBY_EXPORT) || defined(ONIG_ENC_REGISTER))
+# define RUBY
+#endif
 #ifdef RUBY
 # ifndef ONIGMO_REGINT_H
 #  ifndef RUBY_EXTERN

--- a/regint.h
+++ b/regint.h
@@ -102,6 +102,9 @@
 # define ARG_UNUSED
 #endif
 
+#if !defined(RUBY) && defined(RUBY_EXPORT)
+# define RUBY
+#endif
 #ifdef RUBY
 # ifndef RUBY_DEFINES_H
 #  include "ruby/ruby.h"


### PR DESCRIPTION
When CRuby compiles encoding modules (enc/*.[ch]), those modules are
built into each object files. It means they don't include ruby.h.
To switch them CRuby mode, they need to detect another flags.
In this case, they check RUBY_EXPORT and ONIG_ENC_REGISTER.