### PR TITLE
Support gperf 3.1 with backward compatibility

### DIFF
--- a/doc/UnicodeProps.txt
+++ b/doc/UnicodeProps.txt
@@ -1,4 +1,4 @@
-Onigmo (Oniguruma-mod) Unicode Properties  Version 6.2.0    2017/07/17
+Onigmo (Oniguruma-mod) Unicode Properties  Version 6.2.0    2018/03/17
 
 * POSIX brackets
     Alpha

--- a/enc/jis/props.h
+++ b/enc/jis/props.h
@@ -1,4 +1,4 @@
-/* C code produced by gperf version 3.0.4 */
+/* ANSI-C code produced by gperf version 3.1 */
 /* Command-line: gperf -k1,3 -7 -c -j1 -i1 -t -C -P -t --ignore-case -H onig_jis_property_hash -Q onig_jis_property_pool -N onig_jis_property enc/jis/props.kwd  */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -25,7 +25,7 @@
       && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
       && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
-error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
 #line 1 "enc/jis/props.kwd"
@@ -68,7 +68,7 @@ struct enc_property {
     unsigned char ctype;
 };
 
-static const struct enc_property *onig_jis_property(const char *str, unsigned int len);
+static const struct enc_property *onig_jis_property(const char *str, size_t len);
 #line 43 "enc/jis/props.kwd"
 struct enc_property;
 
@@ -107,10 +107,7 @@ static unsigned char gperf_downcase[256] =
 #ifndef GPERF_CASE_STRNCMP
 #define GPERF_CASE_STRNCMP 1
 static int
-gperf_case_strncmp (s1, s2, n)
-     register const char *s1;
-     register const char *s2;
-     register unsigned int n;
+gperf_case_strncmp (register const char *s1, register const char *s2, register size_t n)
 {
   for (; n > 0;)
     {
@@ -135,9 +132,7 @@ inline
 #endif
 #endif
 static unsigned int
-onig_jis_property_hash (str, len)
-     register const char *str;
-     register unsigned int len;
+onig_jis_property_hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
@@ -177,16 +172,8 @@ static const struct onig_jis_property_pool_t onig_jis_property_pool_contents =
     "cyrillic"
   };
 #define onig_jis_property_pool ((const char *) &onig_jis_property_pool_contents)
-#ifdef __GNUC__
-__inline
-#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
-__attribute__ ((__gnu_inline__))
-#endif
-#endif
 const struct enc_property *
-onig_jis_property (str, len)
-     register const char *str;
-     register unsigned int len;
+onig_jis_property (register const char *str, register size_t len)
 {
   static const struct enc_property wordlist[] =
     {
@@ -209,9 +196,9 @@ onig_jis_property (str, len)
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = onig_jis_property_hash (str, len);
+      register unsigned int key = onig_jis_property_hash (str, len);
 
-      if (key <= MAX_HASH_VALUE && key >= 0)
+      if (key <= MAX_HASH_VALUE)
         {
           register int o = wordlist[key].name;
           if (o >= 0)

--- a/enc/unicode/name2ctype.h
+++ b/enc/unicode/name2ctype.h
@@ -1,4 +1,4 @@
-/* C code produced by gperf version 3.0.4 */
+/* ANSI-C code produced by gperf version 3.1 */
 /* Command-line: gperf -7 -c -j1 -i1 -t -C -P -T -H uniname2ctype_hash -Q uniname2ctype_pool -N uniname2ctype_p  */
 #ifndef USE_UNICODE_PROPERTIES
 /* Computed positions: -k'1,3' */
@@ -30,7 +30,7 @@
       && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
       && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
-error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
 
@@ -34756,7 +34756,7 @@ struct uniname2ctype_struct {
 };
 #define uniname2ctype_offset(str) offsetof(struct uniname2ctype_pool_t, uniname2ctype_pool_##str)
 
-static const struct uniname2ctype_struct *uniname2ctype_p(const char *, unsigned int);
+static const struct uniname2ctype_struct *uniname2ctype_p(const char *, size_t);
 
 #ifndef USE_UNICODE_PROPERTIES
 #define TOTAL_KEYWORDS 15
@@ -34786,9 +34786,7 @@ inline
 #endif
 #endif
 static unsigned int
-uniname2ctype_hash (str, len)
-     register const char *str;
-     register unsigned int len;
+uniname2ctype_hash (register const char *str, register size_t len)
 {
 #ifndef USE_UNICODE_PROPERTIES
   static const unsigned char asso_values[] =
@@ -34834,7 +34832,7 @@ uniname2ctype_hash (str, len)
 #ifndef USE_UNICODE_PROPERTIES
   return len + asso_values[(unsigned char)str[2]] + asso_values[(unsigned char)str[0]];
 #else /* USE_UNICODE_PROPERTIES */
-  register int hval = len;
+  register unsigned int hval = len;
 
   switch (hval)
     {
@@ -36536,16 +36534,8 @@ static const struct uniname2ctype_pool_t uniname2ctype_pool_contents =
 #endif /* USE_UNICODE_PROPERTIES */
   };
 #define uniname2ctype_pool ((const char *) &uniname2ctype_pool_contents)
-#ifdef __GNUC__
-__inline
-#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
-__attribute__ ((__gnu_inline__))
-#endif
-#endif
 const struct uniname2ctype_struct *
-uniname2ctype_p (str, len)
-     register const char *str;
-     register unsigned int len;
+uniname2ctype_p (register const char *str, register size_t len)
 {
   static const struct uniname2ctype_struct wordlist[] =
     {
@@ -38352,9 +38342,9 @@ uniname2ctype_p (str, len)
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = uniname2ctype_hash (str, len);
+      register unsigned int key = uniname2ctype_hash (str, len);
 
-      if (key <= MAX_HASH_VALUE && key >= 0)
+      if (key <= MAX_HASH_VALUE)
         {
           register int o = wordlist[key].name;
           if (o >= 0)

--- a/tool/convert-jis-props.sh
+++ b/tool/convert-jis-props.sh
@@ -5,7 +5,15 @@
 # Usage:
 #   ./tool/convert-jis-props.sh enc/jis/props.kwd enc/jis/props.h
 
+GPERF_VERSION=`gperf -v | head -n1 | sed -e 's/^GNU gperf \([0-9]\+\)\.\([0-9]\+.*\)$/\1 \2/' | xargs printf '%02d%02d'`
+if [ $GPERF_VERSION -ge '0301' ]; then
+    # static const struct enc_property *onig_jis_property(const char *str, unsigned int len);
+    GPERF_REPLACE='s/\(onig_jis_property([^,]\+, \).\+\( len)\)/\1size_t\2/'
+else
+    GPERF_REPLACE='#'
+fi
+
 JIS_PROPS_OPTIONS='-k1,3 -7 -c -j1 -i1 -t -C -P -t --ignore-case -H onig_jis_property_hash -Q onig_jis_property_pool -N onig_jis_property'
 
-gperf $JIS_PROPS_OPTIONS $1 | \
+gperf $JIS_PROPS_OPTIONS $1 | sed "$GPERF_REPLACE" | \
     sed 's/(int)(\(long\|size_t\))&((\([a-zA-Z_0-9 ]*[a-zA-Z_0-9]\) *\*)0)->\([a-zA-Z0-9_]*\),/(char)offsetof(\2, \3),/g' > $2

--- a/tool/enc-unicode.rb
+++ b/tool/enc-unicode.rb
@@ -22,6 +22,9 @@ $unicode_version = File.basename(ARGV[0])[/\A[.\d]+\z/]
 
 POSIX_NAMES = %w[NEWLINE Alpha Blank Cntrl Digit Graph Lower Print XPosixPunct Space Upper XDigit Word Alnum ASCII Punct]
 
+GPERF_VERSION = `gperf -v`.split("\n").first # /^GNU gperf (.+)$/
+  .split.last
+
 def pair_codepoints(codepoints)
 
   # We have a sorted Array of codepoints that we wish to partition into
@@ -440,7 +443,7 @@ output.ifdef :USE_UNICODE_PROPERTIES do
   blocks.each{|name|puts"  CR_#{name},"}
 end
 
-puts(<<'__HEREDOC')
+puts(<<"__HEREDOC")
 };
 struct uniname2ctype_struct {
   short name;
@@ -448,7 +451,7 @@ struct uniname2ctype_struct {
 };
 #define uniname2ctype_offset(str) offsetof(struct uniname2ctype_pool_t, uniname2ctype_pool_##str)
 
-static const struct uniname2ctype_struct *uniname2ctype_p(const char *, unsigned int);
+static const struct uniname2ctype_struct *uniname2ctype_p(const char *, #{ GPERF_VERSION >= '3.1' ? 'size_t' : 'unsigned int' });
 %}
 struct uniname2ctype_struct;
 %%


### PR DESCRIPTION
I confirmed that this patch is correct to build with gperf 3.0.4 or earlier and 3.1.

This closes https://github.com/k-takata/Onigmo/issues/94.