### PR TITLE
Use relative include paths (NFC)

### DIFF
--- a/enc/ascii.c
+++ b/enc/ascii.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #ifdef RUBY
 # include "encindex.h"
 #endif

--- a/enc/big5.c
+++ b/enc/big5.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_BIG5[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/enc/cp949.c
+++ b/enc/cp949.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_CP949[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/enc/emacs_mule.c
+++ b/enc/emacs_mule.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 
 #define emacsmule_islead(c)    ((UChar )(c) < 0x9e)

--- a/enc/euc_jp.c
+++ b/enc/euc_jp.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define eucjp_islead(c)    ((UChar )((c) - 0xa1) > 0xfe - 0xa1)
 
@@ -500,7 +500,7 @@ static const OnigCodePoint CR_Cyrillic[] = {
   /* TODO: add JIS X 0212 row 7 */
 }; /* CR_Cyrillic */
 
-#include "enc/jis/props.h"
+#include "jis/props.h"
 
 static int
 property_name_to_ctype(OnigEncoding enc, const UChar* p, const UChar* end)

--- a/enc/euc_kr.c
+++ b/enc/euc_kr.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_EUCKR[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/enc/euc_tw.c
+++ b/enc/euc_tw.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_EUCTW[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/enc/gb18030.c
+++ b/enc/gb18030.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #if 1
 #define DEBUG_GB18030(arg)

--- a/enc/gb2312.c
+++ b/enc/gb2312.c
@@ -1,6 +1,6 @@
 #include <ruby/ruby.h>
 #include <ruby/encoding.h>
-#include "regenc.h"
+#include "../regenc.h"
 
 void
 Init_gb2312(void)

--- a/enc/gbk.c
+++ b/enc/gbk.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_GBK[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/enc/iso_8859_1.c
+++ b/enc/iso_8859_1.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_IS_ISO_8859_1_CTYPE(code,ctype) \

--- a/enc/iso_8859_10.c
+++ b/enc/iso_8859_10.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_10_TO_LOWER_CASE(c) EncISO_8859_10_ToLowerCaseTable[c]

--- a/enc/iso_8859_11.c
+++ b/enc/iso_8859_11.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_IS_ISO_8859_11_CTYPE(code,ctype) \
   ((EncISO_8859_11_CtypeTable[code] & CTYPE_TO_BIT(ctype)) != 0)

--- a/enc/iso_8859_13.c
+++ b/enc/iso_8859_13.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_13_TO_LOWER_CASE(c) EncISO_8859_13_ToLowerCaseTable[c]

--- a/enc/iso_8859_14.c
+++ b/enc/iso_8859_14.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_14_TO_LOWER_CASE(c) EncISO_8859_14_ToLowerCaseTable[c]

--- a/enc/iso_8859_15.c
+++ b/enc/iso_8859_15.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_15_TO_LOWER_CASE(c) EncISO_8859_15_ToLowerCaseTable[c]

--- a/enc/iso_8859_16.c
+++ b/enc/iso_8859_16.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_16_TO_LOWER_CASE(c) EncISO_8859_16_ToLowerCaseTable[c]

--- a/enc/iso_8859_2.c
+++ b/enc/iso_8859_2.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_2_TO_LOWER_CASE(c) EncISO_8859_2_ToLowerCaseTable[c]

--- a/enc/iso_8859_3.c
+++ b/enc/iso_8859_3.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_3_TO_LOWER_CASE(c) EncISO_8859_3_ToLowerCaseTable[c]

--- a/enc/iso_8859_4.c
+++ b/enc/iso_8859_4.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_4_TO_LOWER_CASE(c) EncISO_8859_4_ToLowerCaseTable[c]

--- a/enc/iso_8859_5.c
+++ b/enc/iso_8859_5.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_ISO_8859_5_TO_LOWER_CASE(c) EncISO_8859_5_ToLowerCaseTable[c]
 #define ENC_IS_ISO_8859_5_CTYPE(code,ctype) \

--- a/enc/iso_8859_6.c
+++ b/enc/iso_8859_6.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_IS_ISO_8859_6_CTYPE(code,ctype) \
   ((EncISO_8859_6_CtypeTable[code] & CTYPE_TO_BIT(ctype)) != 0)

--- a/enc/iso_8859_7.c
+++ b/enc/iso_8859_7.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_ISO_8859_7_TO_LOWER_CASE(c) EncISO_8859_7_ToLowerCaseTable[c]
 #define ENC_IS_ISO_8859_7_CTYPE(code,ctype) \

--- a/enc/iso_8859_8.c
+++ b/enc/iso_8859_8.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_IS_ISO_8859_8_CTYPE(code,ctype) \
   ((EncISO_8859_8_CtypeTable[code] & CTYPE_TO_BIT(ctype)) != 0)

--- a/enc/iso_8859_9.c
+++ b/enc/iso_8859_9.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_ISO_8859_9_TO_LOWER_CASE(c) EncISO_8859_9_ToLowerCaseTable[c]

--- a/enc/koi8_r.c
+++ b/enc/koi8_r.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_KOI8_R_TO_LOWER_CASE(c) EncKOI8_R_ToLowerCaseTable[c]
 #define ENC_IS_KOI8_R_CTYPE(code,ctype) \

--- a/enc/koi8_u.c
+++ b/enc/koi8_u.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_KOI8_U_TO_LOWER_CASE(c) EncKOI8_U_ToLowerCaseTable[c]
 #define ENC_IS_KOI8_U_CTYPE(code,ctype) \

--- a/enc/mktable.c
+++ b/enc/mktable.c
@@ -37,7 +37,7 @@
 
 #include <ctype.h>
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ASCII                0
 #define UNICODE_ISO_8859_1   1

--- a/enc/shift_jis.h
+++ b/enc/shift_jis.h
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 static const int EncLen_SJIS[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -487,7 +487,7 @@ static const OnigCodePoint CR_Cyrillic[] = {
   0x8480, 0x8491,
 }; /* CR_Cyrillic */
 
-#include "enc/jis/props.h"
+#include "jis/props.h"
 
 static int
 property_name_to_ctype(OnigEncoding enc, const UChar* p, const UChar* end)

--- a/enc/unicode.c
+++ b/enc/unicode.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regint.h"
+#include "../regint.h"
 
 #define ONIGENC_IS_UNICODE_ISO_8859_1_CTYPE(code,ctype) \
   ((EncUNICODE_ISO_8859_1_CtypeTable[code] & CTYPE_TO_BIT(ctype)) != 0)
@@ -162,7 +162,7 @@ code3_equal(const OnigCodePoint *x, const OnigCodePoint *y)
 #define I(n) OnigSpecialIndexEncode(n)
 #define L(n) SpecialsLengthEncode(n)
 
-#include "casefold.h"
+#include "unicode/casefold.h"
 
 #undef U
 #undef D
@@ -174,7 +174,7 @@ code3_equal(const OnigCodePoint *x, const OnigCodePoint *y)
 #undef I
 #undef L
 
-#include "name2ctype.h"
+#include "unicode/name2ctype.h"
 
 #define CODE_RANGES_NUM numberof(CodeRanges)
 

--- a/enc/us_ascii.c
+++ b/enc/us_ascii.c
@@ -1,4 +1,4 @@
-#include "regenc.h"
+#include "../regenc.h"
 #ifdef RUBY
 # include "encindex.h"
 #endif

--- a/enc/utf_16be.c
+++ b/enc/utf_16be.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #if 0

--- a/enc/utf_16le.c
+++ b/enc/utf_16le.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #if 0

--- a/enc/utf_32be.c
+++ b/enc/utf_32be.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 static OnigCodePoint utf32be_mbc_to_code(const UChar* p, const UChar* end, OnigEncoding enc);

--- a/enc/utf_32le.c
+++ b/enc/utf_32le.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 static OnigCodePoint utf32le_mbc_to_code(const UChar* p, const UChar* end, OnigEncoding enc);

--- a/enc/utf_8.c
+++ b/enc/utf_8.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #ifdef RUBY
 # include "encindex.h"
 #endif

--- a/enc/windows_1250.c
+++ b/enc/windows_1250.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_CP1250_TO_LOWER_CASE(c) EncCP1250_ToLowerCaseTable[c]

--- a/enc/windows_1251.c
+++ b/enc/windows_1251.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_CP1251_TO_LOWER_CASE(c) EncCP1251_ToLowerCaseTable[c]
 #define ENC_IS_CP1251_CTYPE(code,ctype) \

--- a/enc/windows_1252.c
+++ b/enc/windows_1252.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_CP1252_TO_LOWER_CASE(c) EncCP1252_ToLowerCaseTable[c]

--- a/enc/windows_1253.c
+++ b/enc/windows_1253.c
@@ -35,7 +35,7 @@
  * Link: http://en.wikipedia.org/wiki/Windows-1253
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 
 #define ENC_CP1253_TO_LOWER_CASE(c) EncCP1253_ToLowerCaseTable[c]
 #define ENC_IS_CP1253_CTYPE(code,ctype) \

--- a/enc/windows_1254.c
+++ b/enc/windows_1254.c
@@ -35,7 +35,7 @@
  * Link: http://en.wikipedia.org/wiki/Windows-1254
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 #define ENC_CP1254_TO_LOWER_CASE(c) EncCP1254_ToLowerCaseTable[c]

--- a/enc/windows_1257.c
+++ b/enc/windows_1257.c
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "regenc.h"
+#include "../regenc.h"
 #include "iso_8859.h"
 
 /*


### PR DESCRIPTION
This allows the project to be built without specifying header search paths, which is necessary to import it as a SwiftPM package.