### PR TITLE
Extend doc about subexpression calls

### DIFF
--- a/doc/RE
+++ b/doc/RE
@@ -425,6 +425,10 @@ syntax: ONIG_SYNTAX_RUBY (default)
   * The option status of the called group is always effective.
 
     ex. /(?-i:\g<name>)(?i:(?<name>a)){0}/.match("A")
+    
+  * Backreferences target the last occurrence of the called group.
+
+    ex. /(.)\g<1>\1/.match("ABB")
 
   * ONIG_SYNTAX_PERL:
     Use (?&name), (?n), (?-n), (?+n), (?R) or (?0) instead of \g<>.


### PR DESCRIPTION
I expected `/(.)\g<1>\1/` to match `ABA`. Perhaps the docs should state in some way that the matched text used for backreferences is determined by the closest occurrence of the target group - be it a subexp call or the original group.