### PR TITLE
avoid negative character

### DIFF
--- a/regenc.c
+++ b/regenc.c
@@ -997,7 +997,8 @@ onigenc_single_byte_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar
 
     if (code >= 'a' && code <= 'z' && (flags & ONIGENC_CASE_UPCASE)) {
       flags |= ONIGENC_CASE_MODIFIED;
-      code += 'A' - 'a';
+      code -= 'a';
+      code += 'A';
     } else if (code >= 'A' && code <= 'Z' &&
 	(flags & (ONIGENC_CASE_DOWNCASE | ONIGENC_CASE_FOLD))) {
       flags |= ONIGENC_CASE_MODIFIED;


### PR DESCRIPTION
In ASCII, `'a'` is bigger than `'A'`.  Which means `'A' - 'a'` is a negative number (-32, to be precise). In C, the type of `'a'` and `'A'` is `signed int`.  So `'A' - 'a'` is also `signed int`.  It is `(signed int)-32`.

The problem is, `OnigCodePoint` is `unsigned int`.  Adding a negative number to a variable of `OnigCodepoint` (`code` here) introduces an unintentional cast of `(unsigned)(signed)-32`, which is 4,294,967,264. Adding this value to code then overflows, and the result eventually becomes normal codepoint.

The series of operations are not a serious problem but because `code >= 'a'` holds, we can `(code - 'a') + 'A'` to reroute this.

See also https://travis-ci.org/ruby/ruby/jobs/452680646#L2190