### PR TITLE
extend utf8 to 31bits

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,18 +81,22 @@ mktable: $(encdir)/mktable.c $(srcdir)/regenc.h
 # TEST
 TESTS = testc testp testcu
 
-check_PROGRAMS = testc testp testcu
+check_PROGRAMS = testc testp testcu \
+	test_enc_utf8
 
 test: atest pytest
 	$(MAKE) -C sample test
 
-atest: testc$(EXEEXT) testp$(EXEEXT) testcu$(EXEEXT)
+atest: testc$(EXEEXT) testp$(EXEEXT) testcu$(EXEEXT) \
+    test_enc_utf8$(EXEEXT)
 	@echo "[Onigmo API, ASCII/EUC-JP check]"
 	@$(top_builddir)/testc  | grep RESULT
 	@echo "[POSIX API, ASCII/EUC-JP check]"
 	@$(top_builddir)/testp  | grep RESULT
 	@echo "[Onigmo API, UTF-16 check]"
 	@$(top_builddir)/testcu | grep RESULT
+	@echo "[UTF-8 codec check]"
+	@$(top_builddir)/test_enc_utf8 | grep RESULT
 
 testc_SOURCES = testc.c
 testc_LDADD = libonigmo.la
@@ -104,6 +108,8 @@ testp_CFLAGS = -DPOSIX_TEST
 testcu_SOURCES = testu.c
 testcu_LDADD = libonigmo.la
 
+test_enc_utf8_SOURCES = test_enc_utf8.c
+test_enc_utf8_LDADD = libonigmo.la
 
 #$(srcdir)/testc.c: $(srcdir)/test.rb $(srcdir)/testconv.rb
 $(srcdir)/testc.c:

--- a/enc/utf_8.c
+++ b/enc/utf_8.c
@@ -37,7 +37,7 @@
 #endif
 
 #define USE_INVALID_CODE_SCHEME
-#define USE_UTF8_31BITS
+/* #define USE_UTF8_31BITS */
 
 #ifdef USE_INVALID_CODE_SCHEME
 /* virtual codepoint values for invalid encoding byte 0xfe and 0xff */

--- a/enc/utf_8.c
+++ b/enc/utf_8.c
@@ -37,13 +37,19 @@
 #endif
 
 #define USE_INVALID_CODE_SCHEME
+#define USE_UTF8_31BITS
 
 #ifdef USE_INVALID_CODE_SCHEME
 /* virtual codepoint values for invalid encoding byte 0xfe and 0xff */
 # define INVALID_CODE_FE  0xfffffffe
 # define INVALID_CODE_FF  0xffffffff
 #endif
+
+#ifndef USE_UTF8_31BITS
 #define VALID_CODE_LIMIT  0x0010ffff
+#else
+#define VALID_CODE_LIMIT  0x7fffffff
+#endif
 
 #define utf8_islead(c)     ((UChar )((c) & 0xc0) != 0x80)
 
@@ -63,14 +69,19 @@ static const int EncLen_UTF8[] = {
   2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
   2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
   3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+#ifndef USE_UTF8_31BITS
   4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+#else
+  4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 1, 1
+#endif
 };
 
 typedef enum {
   FAILURE = -2,
   ACCEPT,
   S0, S1, S2, S3,
-  S4, S5, S6, S7
+  S4, S5, S6, S7,
+  S8, S9,S10,S11,
 } state_t;
 #define A ACCEPT
 #define F FAILURE
@@ -91,7 +102,11 @@ static const signed char trans[][0x100] = {
     /* c */ F, F, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     /* d */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     /* e */ 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
+#ifndef USE_UTF8_31BITS
     /* f */ 5, 6, 6, 6, 7, F, F, F, F, F, F, F, F, F, F, F
+#else
+    /* f */ 5, 6, 6, 6, 6, 6, 6, 6, 8, 9, 9, 9,10,11, F, F
+#endif
   },
   { /* S1   0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
     /* 0 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
@@ -219,6 +234,80 @@ static const signed char trans[][0x100] = {
     /* e */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
     /* f */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F
   },
+#ifdef USE_UTF8_31BITS
+  { /* S8   0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
+    /* 0 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 1 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 2 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 3 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 4 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 5 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 6 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 7 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 8 */ F, F, F, F, F, F, F, F, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* 9 */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* a */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* b */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* c */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* d */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* e */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* f */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F
+  },
+  { /* S9   0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
+    /* 0 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 1 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 2 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 3 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 4 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 5 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 6 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 7 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 8 */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* 9 */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* a */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* b */ 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    /* c */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* d */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* e */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* f */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F
+  },
+  { /* S10  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
+    /* 0 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 1 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 2 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 3 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 4 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 5 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 6 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 7 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 8 */ F, F, F, F, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* 9 */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* a */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* b */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* c */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* d */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* e */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* f */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F
+  },
+  { /* S11  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
+    /* 0 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 1 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 2 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 3 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 4 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 5 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 6 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 7 */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* 8 */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* 9 */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* a */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* b */ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    /* c */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* d */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* e */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+    /* f */ F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F
+  },
+#endif // USE_UTF8_31BITS
 };
 #undef A
 #undef F
@@ -244,8 +333,24 @@ mbc_enc_len(const UChar* p, const UChar* e, OnigEncoding enc ARG_UNUSED)
 
   if (p == e) return ONIGENC_CONSTRUCT_MBCLEN_NEEDMORE(EncLen_UTF8[firstbyte]-3);
   s = trans[s][*p++];
+
+#ifndef USE_UTF8_31BITS
   return s == ACCEPT ? ONIGENC_CONSTRUCT_MBCLEN_CHARFOUND(4) :
                        ONIGENC_CONSTRUCT_MBCLEN_INVALID();
+#else
+  if (s < 0) return s == ACCEPT ? ONIGENC_CONSTRUCT_MBCLEN_CHARFOUND(4) :
+                                  ONIGENC_CONSTRUCT_MBCLEN_INVALID();
+
+  if (p == e) return ONIGENC_CONSTRUCT_MBCLEN_NEEDMORE(EncLen_UTF8[firstbyte]-4);
+  s = trans[s][*p++];
+  if (s < 0) return s == ACCEPT ? ONIGENC_CONSTRUCT_MBCLEN_CHARFOUND(5) :
+                                  ONIGENC_CONSTRUCT_MBCLEN_INVALID();
+
+  if (p == e) return ONIGENC_CONSTRUCT_MBCLEN_NEEDMORE(EncLen_UTF8[firstbyte]-5);
+  s = trans[s][*p++];
+  return s == ACCEPT ? ONIGENC_CONSTRUCT_MBCLEN_CHARFOUND(6) :
+                       ONIGENC_CONSTRUCT_MBCLEN_INVALID();
+#endif
 }
 
 static int
@@ -304,7 +409,13 @@ code_to_mbclen(OnigCodePoint code, OnigEncoding enc ARG_UNUSED)
   if      ((code & 0xffffff80) == 0) return 1;
   else if ((code & 0xfffff800) == 0) return 2;
   else if ((code & 0xffff0000) == 0) return 3;
+#ifndef USE_UTF8_31BITS
   else if (code <= VALID_CODE_LIMIT) return 4;
+#else
+  else if ((code & 0xffe00000) == 0) return 4;
+  else if ((code & 0xfc000000) == 0) return 5;
+  else if (code <= VALID_CODE_LIMIT) return 6;
+#endif
 #ifdef USE_INVALID_CODE_SCHEME
   else if (code == INVALID_CODE_FE) return 1;
   else if (code == INVALID_CODE_FF) return 1;
@@ -333,11 +444,33 @@ code_to_mbc(OnigCodePoint code, UChar *buf, OnigEncoding enc ARG_UNUSED)
       *p++ = (UChar )(((code>>12) & 0x0f) | 0xe0);
       *p++ = UTF8_TRAILS(code, 6);
     }
+#ifndef USE_UTF8_31BITS
     else if (code <= VALID_CODE_LIMIT) {
       *p++ = (UChar )(((code>>18) & 0x07) | 0xf0);
       *p++ = UTF8_TRAILS(code, 12);
       *p++ = UTF8_TRAILS(code,  6);
     }
+#else
+    else if ((code & 0xffe00000) == 0) {
+        *p++ = (UChar )(((code>>18) & 0x07) | 0xf0);
+        *p++ = UTF8_TRAILS(code, 12);
+        *p++ = UTF8_TRAILS(code,  6);
+    }
+    else if ((code & 0xfc000000) == 0) {
+        *p++ = (UChar )(((code>>24) & 0x03) | 0xf8);
+        *p++ = UTF8_TRAILS(code, 18);
+        *p++ = UTF8_TRAILS(code, 12);
+        *p++ = UTF8_TRAILS(code,  6);
+    }
+    else if (code <= VALID_CODE_LIMIT) {
+        *p++ = (UChar )(((code>>30) & 0x01) | 0xfc);
+        *p++ = UTF8_TRAILS(code, 24);
+        *p++ = UTF8_TRAILS(code, 18);
+        *p++ = UTF8_TRAILS(code, 12);
+        *p++ = UTF8_TRAILS(code,  6);
+    }
+#endif
+
 #ifdef USE_INVALID_CODE_SCHEME
     else if (code == INVALID_CODE_FE) {
       *p = 0xfe;
@@ -417,7 +550,11 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 OnigEncodingDefine(utf_8, UTF_8) = {
   mbc_enc_len,
   "UTF-8",     /* name */
+#ifndef USE_UTF8_31BITS
   4,           /* max byte length */
+#else
+  6,           /* max byte length */
+#endif
   1,           /* min byte length */
   is_mbc_newline,
   mbc_to_code,

--- a/test_enc_utf8.c
+++ b/test_enc_utf8.c
@@ -9,7 +9,7 @@
 
 #include "onigmo.h"
 
-#define USE_UTF8_31BITS
+/* #define USE_UTF8_31BITS */
 
 #define SLEN(s)  strlen(s)
 

--- a/test_enc_utf8.c
+++ b/test_enc_utf8.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "onigmo.h"
 
@@ -94,8 +95,10 @@ static void n(char* pattern, char* str)
   xx(pattern, str, 0, 0, 0, 1);
 }
 
+const OnigEncodingType * target_encoding = ONIG_ENCODING_UTF8;
+
 static void test_mbc_enc_len(const char * str, int expect) {
-  const OnigEncodingType * enc = ONIG_ENCODING_UTF8;
+  const OnigEncodingType * enc = target_encoding;
   size_t len = strlen(str);
   int actual = ONIGENC_PRECISE_MBC_ENC_LEN(enc, (const UChar *)str, (const UChar *)str + len);
   if (actual == expect) {
@@ -107,6 +110,60 @@ static void test_mbc_enc_len(const char * str, int expect) {
   }
 }
 
+static void test_code_to_mbclen(OnigCodePoint code, int expect) {
+  const OnigEncodingType * enc = target_encoding;
+  int actual = ONIGENC_CODE_TO_MBCLEN(enc, code);
+  if (actual == expect) {
+    fprintf(stdout, "OK: code_to_mbclen(U+%04X)=%d\n", code, expect);
+    nsucc++;
+  } else {
+    fprintf(stdout, "FAIL: code_to_mbclen(U+%04X)=%d\n", code, expect);
+    nfail++;
+  }
+}
+
+static void test_mbc_to_code(const char * str, int expect) {
+  const OnigEncodingType * enc = target_encoding;
+  size_t len = strlen(str);
+  int actual = ONIGENC_MBC_TO_CODE(enc, (const UChar *)str, (const UChar *)str + len);
+  if (actual == expect) {
+    fprintf(stdout, "OK: mbc_to_code(%s)=U+%04X\n", str, expect);
+    nsucc++;
+  } else {
+    fprintf(stdout, "FAIL: mbc_to_code(%s)=U+%04X\n", str, expect);
+    nfail++;
+  }
+}
+
+static void test_code_to_mbc(OnigCodePoint code, const char * expect, int exp_error) {
+  const OnigEncodingType * enc = target_encoding;
+  UChar * buf = (UChar *)malloc(ONIGENC_MBC_MAXLEN(enc) + 1);
+  int len = ONIGENC_CODE_TO_MBC(enc, code, buf);
+  if (len < 0) {
+    int err = len;
+    if (err == exp_error) {
+      fprintf(stdout, "OK: code_to_mbc(U+%04X)=(error %d)\n", code, len);
+      nsucc++;
+    } else {
+      fprintf(stdout, "FAIL: code_to_mbc(U+%04X)=(error %d)\n", code, len);
+      nfail++;
+    }
+    goto exit;
+  }
+
+  buf[len] = '\0';
+  if (strcmp((const char *)buf, expect) == 0) {
+    fprintf(stdout, "OK: code_to_mbc(U+%04X)=%s\n", code, expect);
+    nsucc++;
+  } else {
+    fprintf(stdout, "FAIL: code_to_mbc(U+%04X)=%s\n", code, expect);
+    nfail++;
+  }
+
+exit:
+  free(buf);
+}
+
 extern int main(int argc, char* argv[])
 {
   err_file = stdout;
@@ -114,40 +171,54 @@ extern int main(int argc, char* argv[])
   region = onig_region_new();
 
   test_mbc_enc_len("\xC2\x80", 2);            // S0, S1, A
+  test_code_to_mbclen(0x0080, 2);
+  test_code_to_mbc(0x0080, "\xC2\x80", 0);
   x2("\\x{0080}", "\xC2\x80", 0, 2);
   x2("\xC2\x80", "\xC2\x80", 0, 2);           // min 2 bytes
     
   test_mbc_enc_len("\xC2\xC0", -1);           // S0, S1, F
 
   test_mbc_enc_len("\xDF\xBF", 2);            // S0, S1, A
+  test_code_to_mbclen(0x07FF, 2);
+  test_code_to_mbc(0x07FF, "\xDF\xBF", 0);
   x2("\\x{07FF}", "\xDF\xBF", 0, 2);
   x2("\xDF\xBF", "\xDF\xBF", 0, 2);           // max 2 bytes
   
   test_mbc_enc_len("\xE0\xA0\x80", 3);        // S0, S2, S1, A
+  test_code_to_mbclen(0x0800, 3);
+  test_code_to_mbc(0x0800, "\xE0\xA0\x80", 0);
   x2("\xE0\xA0\x80", "\xE0\xA0\x80", 0, 3);
   x2("\\x{0800}", "\xE0\xA0\x80", 0, 3);      // min 3 bytes
 
   test_mbc_enc_len("\xE0\xC0\x80", -1);       // S0, S2, F
 
   test_mbc_enc_len("\xEF\xBF\xBF", 3);        // S0, S3, S1, A
+  test_code_to_mbclen(0xFFFF, 3);
+  test_code_to_mbc(0xFFFF, "\xEF\xBF\xBF", 0);
   x2("\xEF\xBF\xBF", "\xEF\xBF\xBF", 0, 3);
   x2("\\x{FFFF}", "\xEF\xBF\xBF", 0, 3);      // max 3 bytes
   
   test_mbc_enc_len("\xEF\xC0\xBF", -1);       // S0, S3, F
   
   test_mbc_enc_len("\xED\x80\x80", 3);        // S0, S4, S1, A
+  test_code_to_mbclen(0xD000, 3);
+  test_code_to_mbc(0xD000, "\xED\x80\x80", 0);
   x2("\xED\x80\x80", "\xED\x80\x80", 0, 3);
   x2("\\x{D000}", "\xED\x80\x80", 0, 3);
   
   test_mbc_enc_len("\xED\xA0\xA0", -1);       // S0, S4, F
   
   test_mbc_enc_len("\xF0\x90\x80\x80", 4);    // S0, S5, S3, S1, A
+  test_code_to_mbclen(0x00010000, 4);
+  test_code_to_mbc(0x00010000, "\xF0\x90\x80\x80", 0);
   x2("\xF0\x90\x80\x80", "\xF0\x90\x80\x80", 0, 4);
   x2("\\x{00010000}", "\xF0\x90\x80\x80", 0, 4); // min 4 bytes
   
   test_mbc_enc_len("\xF0\x80\x80\x80", -1);   // S0, S5, F
 
   test_mbc_enc_len("\xF4\x8F\xBF\xBF", 4);    // S0, S7, S3, S1, A
+  test_code_to_mbclen(0x0010FFFF, 4);
+  test_code_to_mbc(0x0010FFFF, "\xF4\x8F\xBF\xBF", 0);
   x2("\xF4\x8F\xBF\xBF", "\xF4\x8F\xBF\xBF", 0, 4);
   x2("\\x{0010FFFF}", "\xF4\x8F\xBF\xBF", 0, 4); // max Unicode
 
@@ -155,34 +226,57 @@ extern int main(int argc, char* argv[])
   test_mbc_enc_len("\xF7\xBF\xBF\xBF", -1);           // S0, F
 #else
   test_mbc_enc_len("\xF7\xBF\xBF\xBF", 4);            // S0, S6, S3, S1, A
+  test_code_to_mbclen(0x001FFFFF, 4);
+  test_code_to_mbc(0x001FFFFF, "\xF7\xBF\xBF\xBF", 0);
   x2("\xF7\xBF\xBF\xBF", "\xF7\xBF\xBF\xBF", 0, 4);
   x2("\\x{001FFFFF}", "\xF7\xBF\xBF\xBF", 0, 4);      // max 4 bytes (21bits)
   
   test_mbc_enc_len("\xF7\xC0\xBF\xBF", -1);           // S0, S6, F
   
   test_mbc_enc_len("\xF8\x88\x80\x80\x80", 5);        // S0, S8, S6, S3, S1, A
+  test_code_to_mbclen(0x00200000, 5);
+  test_code_to_mbc(0x00200000, "\xF8\x88\x80\x80\x80", 0);
   x2("\xF8\x88\x80\x80\x80", "\xF8\x88\x80\x80\x80", 0, 5);
   x2("\\x{00200000}", "\xF8\x88\x80\x80\x80", 0, 5);  // min 5 bytes
   
   test_mbc_enc_len("\xF8\x80\x80\x80\x80", -1);       // S0, S8, F
   
   test_mbc_enc_len("\xFB\xBF\xBF\xBF\xBF", 5);        // S0, S9, S6, S3, S1, A
+  test_code_to_mbclen(0x03FFFFFF, 5);
+  test_code_to_mbc(0x03FFFFFF, "\xFB\xBF\xBF\xBF\xBF", 0);
   x2("\xFB\xBF\xBF\xBF\xBF", "\xFB\xBF\xBF\xBF\xBF", 0, 5);
   x2("\\x{03FFFFFF}", "\xFB\xBF\xBF\xBF\xBF", 0, 5);  // max 5 bytes
   
   test_mbc_enc_len("\xFB\xC0\xBF\xBF\xBF", -1);       // S0, S9, F
   
   test_mbc_enc_len("\xFC\x84\x80\x80\x80\x80", 6);    // S0, S10, S9, S6, S3, S1, A
+  test_code_to_mbclen(0x04000000, 6);
+  test_code_to_mbc(0x04000000, "\xFC\x84\x80\x80\x80\x80", 0);
   x2("\xFC\x84\x80\x80\x80\x80", "\xFC\x84\x80\x80\x80\x80", 0, 6);
   x2("\\x{04000000}", "\xFC\x84\x80\x80\x80\x80", 0, 6); // min 6 bytes
   
   test_mbc_enc_len("\xFC\x80\x80\x80\x80\x80", -1);   // S0, S10, F
   
   test_mbc_enc_len("\xFD\xBF\xBF\xBF\xBF\xBF", 6);    // S0, S11, S9, S6, S3, S1, A
+  test_code_to_mbclen(0x7FFFFFFF, 6);
+  test_code_to_mbc(0x7FFFFFFF, "\xFD\xBF\xBF\xBF\xBF\xBF", 0);
   x2("\xFD\xBF\xBF\xBF\xBF\xBF", "\xFD\xBF\xBF\xBF\xBF\xBF", 0, 6);
   x2("\\x{7FFFFFFF}", "\xFD\xBF\xBF\xBF\xBF\xBF", 0, 6); // max 6 bytes
   
   test_mbc_enc_len("\xFD\xC0\xBF\xBF\xBF\xBF", -1);   // S0, S11, F
+
+  test_code_to_mbclen(0x80000000, ONIGERR_TOO_BIG_WIDE_CHAR_VALUE);
+  test_code_to_mbc(0x80000000, "", ONIGERR_TOO_BIG_WIDE_CHAR_VALUE);
+  test_code_to_mbclen(0xFFFFFFFD, ONIGERR_TOO_BIG_WIDE_CHAR_VALUE);
+  test_code_to_mbc(0xFFFFFFFD, "", ONIGERR_TOO_BIG_WIDE_CHAR_VALUE);
+  test_code_to_mbclen(0xFFFFFFFE, 1);
+  test_code_to_mbc(0xFFFFFFFE, "\xFE", 0);
+  test_code_to_mbclen(0xFFFFFFFF, 1);
+  test_code_to_mbc(0xFFFFFFFF, "\xFF", 0);
+
+  test_mbc_to_code("\xFE", 0xFFFFFFFE);
+  test_mbc_to_code("\xFF", 0xFFFFFFFF);
+
 #endif
 
   fprintf(stdout,

--- a/test_enc_utf8.c
+++ b/test_enc_utf8.c
@@ -1,0 +1,196 @@
+#include "config.h"
+#ifdef ONIG_ESCAPE_UCHAR_COLLISION
+#undef ONIG_ESCAPE_UCHAR_COLLISION
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#include "onigmo.h"
+
+#define USE_UTF8_31BITS
+
+#define SLEN(s)  strlen(s)
+
+static int nsucc  = 0;
+static int nfail  = 0;
+static int nerror = 0;
+
+static FILE* err_file;
+
+static OnigRegion* region;
+
+static void xx(char* pattern, char* str, int from, int to, int mem, int not)
+{
+  int r;
+
+  regex_t* reg;
+  OnigErrorInfo einfo;
+  OnigSyntaxType syn = *ONIG_SYNTAX_DEFAULT;
+
+  r = onig_new(&reg, (UChar* )pattern, (UChar* )(pattern + SLEN(pattern)),
+	       ONIG_OPTION_NONE, ONIG_ENCODING_UTF8, &syn, &einfo);
+  if (r) {
+    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    onig_error_code_to_str((UChar* )s, r, &einfo);
+    fprintf(err_file, "ERROR: %s\n", s);
+    nerror++;
+    return ;
+  }
+
+  r = onig_search(reg, (UChar* )str, (UChar* )(str + SLEN(str)),
+		  (UChar* )str, (UChar* )(str + SLEN(str)),
+		  region, ONIG_OPTION_NONE);
+  if (r < ONIG_MISMATCH) {
+    char s[ONIG_MAX_ERROR_MESSAGE_LEN];
+    onig_error_code_to_str((UChar* )s, r);
+    fprintf(err_file, "ERROR: %s\n", s);
+    nerror++;
+    return ;
+  }
+
+  if (r == ONIG_MISMATCH) {
+    if (not) {
+      fprintf(stdout, "OK(N): /%s/ '%s'\n", pattern, str);
+      nsucc++;
+    }
+    else {
+      fprintf(stdout, "FAIL: /%s/ '%s'\n", pattern, str);
+      nfail++;
+    }
+  }
+  else {
+    if (not) {
+      fprintf(stdout, "FAIL(N): /%s/ '%s'\n", pattern, str);
+      nfail++;
+    }
+    else {
+      if (region->beg[mem] == from && region->end[mem] == to) {
+        fprintf(stdout, "OK: /%s/ '%s'\n", pattern, str);
+        nsucc++;
+      }
+      else {
+        fprintf(stdout, "FAIL: /%s/ '%s' %d-%d : %d-%d\n", pattern, str,
+	        (int)from, (int)to, (int)region->beg[mem], (int)region->end[mem]);
+        nfail++;
+      }
+    }
+  }
+  onig_free(reg);
+}
+
+static void x2(char* pattern, char* str, int from, int to)
+{
+  xx(pattern, str, from, to, 0, 0);
+}
+
+static void x3(char* pattern, char* str, int from, int to, int mem)
+{
+  xx(pattern, str, from, to, mem, 0);
+}
+
+static void n(char* pattern, char* str)
+{
+  xx(pattern, str, 0, 0, 0, 1);
+}
+
+static void test_mbc_enc_len(const char * str, int expect) {
+  const OnigEncodingType * enc = ONIG_ENCODING_UTF8;
+  size_t len = strlen(str);
+  int actual = ONIGENC_PRECISE_MBC_ENC_LEN(enc, (const UChar *)str, (const UChar *)str + len);
+  if (actual == expect) {
+    fprintf(stdout, "OK: mbc_enc_len(%s)=%d\n", str, expect);
+    nsucc++;
+  } else {
+    fprintf(stdout, "FAIL: mbc_enc_len(%s)=%d\n", str, expect);
+    nfail++;
+  }
+}
+
+extern int main(int argc, char* argv[])
+{
+  err_file = stdout;
+
+  region = onig_region_new();
+
+  test_mbc_enc_len("\xC2\x80", 2);            // S0, S1, A
+  x2("\\x{0080}", "\xC2\x80", 0, 2);
+  x2("\xC2\x80", "\xC2\x80", 0, 2);           // min 2 bytes
+    
+  test_mbc_enc_len("\xC2\xC0", -1);           // S0, S1, F
+
+  test_mbc_enc_len("\xDF\xBF", 2);            // S0, S1, A
+  x2("\\x{07FF}", "\xDF\xBF", 0, 2);
+  x2("\xDF\xBF", "\xDF\xBF", 0, 2);           // max 2 bytes
+  
+  test_mbc_enc_len("\xE0\xA0\x80", 3);        // S0, S2, S1, A
+  x2("\xE0\xA0\x80", "\xE0\xA0\x80", 0, 3);
+  x2("\\x{0800}", "\xE0\xA0\x80", 0, 3);      // min 3 bytes
+
+  test_mbc_enc_len("\xE0\xC0\x80", -1);       // S0, S2, F
+
+  test_mbc_enc_len("\xEF\xBF\xBF", 3);        // S0, S3, S1, A
+  x2("\xEF\xBF\xBF", "\xEF\xBF\xBF", 0, 3);
+  x2("\\x{FFFF}", "\xEF\xBF\xBF", 0, 3);      // max 3 bytes
+  
+  test_mbc_enc_len("\xEF\xC0\xBF", -1);       // S0, S3, F
+  
+  test_mbc_enc_len("\xED\x80\x80", 3);        // S0, S4, S1, A
+  x2("\xED\x80\x80", "\xED\x80\x80", 0, 3);
+  x2("\\x{D000}", "\xED\x80\x80", 0, 3);
+  
+  test_mbc_enc_len("\xED\xA0\xA0", -1);       // S0, S4, F
+  
+  test_mbc_enc_len("\xF0\x90\x80\x80", 4);    // S0, S5, S3, S1, A
+  x2("\xF0\x90\x80\x80", "\xF0\x90\x80\x80", 0, 4);
+  x2("\\x{00010000}", "\xF0\x90\x80\x80", 0, 4); // min 4 bytes
+  
+  test_mbc_enc_len("\xF0\x80\x80\x80", -1);   // S0, S5, F
+
+  test_mbc_enc_len("\xF4\x8F\xBF\xBF", 4);    // S0, S7, S3, S1, A
+  x2("\xF4\x8F\xBF\xBF", "\xF4\x8F\xBF\xBF", 0, 4);
+  x2("\\x{0010FFFF}", "\xF4\x8F\xBF\xBF", 0, 4); // max Unicode
+
+#ifndef USE_UTF8_31BITS
+  test_mbc_enc_len("\xF7\xBF\xBF\xBF", -1);           // S0, F
+#else
+  test_mbc_enc_len("\xF7\xBF\xBF\xBF", 4);            // S0, S6, S3, S1, A
+  x2("\xF7\xBF\xBF\xBF", "\xF7\xBF\xBF\xBF", 0, 4);
+  x2("\\x{001FFFFF}", "\xF7\xBF\xBF\xBF", 0, 4);      // max 4 bytes (21bits)
+  
+  test_mbc_enc_len("\xF7\xC0\xBF\xBF", -1);           // S0, S6, F
+  
+  test_mbc_enc_len("\xF8\x88\x80\x80\x80", 5);        // S0, S8, S6, S3, S1, A
+  x2("\xF8\x88\x80\x80\x80", "\xF8\x88\x80\x80\x80", 0, 5);
+  x2("\\x{00200000}", "\xF8\x88\x80\x80\x80", 0, 5);  // min 5 bytes
+  
+  test_mbc_enc_len("\xF8\x80\x80\x80\x80", -1);       // S0, S8, F
+  
+  test_mbc_enc_len("\xFB\xBF\xBF\xBF\xBF", 5);        // S0, S9, S6, S3, S1, A
+  x2("\xFB\xBF\xBF\xBF\xBF", "\xFB\xBF\xBF\xBF\xBF", 0, 5);
+  x2("\\x{03FFFFFF}", "\xFB\xBF\xBF\xBF\xBF", 0, 5);  // max 5 bytes
+  
+  test_mbc_enc_len("\xFB\xC0\xBF\xBF\xBF", -1);       // S0, S9, F
+  
+  test_mbc_enc_len("\xFC\x84\x80\x80\x80\x80", 6);    // S0, S10, S9, S6, S3, S1, A
+  x2("\xFC\x84\x80\x80\x80\x80", "\xFC\x84\x80\x80\x80\x80", 0, 6);
+  x2("\\x{04000000}", "\xFC\x84\x80\x80\x80\x80", 0, 6); // min 6 bytes
+  
+  test_mbc_enc_len("\xFC\x80\x80\x80\x80\x80", -1);   // S0, S10, F
+  
+  test_mbc_enc_len("\xFD\xBF\xBF\xBF\xBF\xBF", 6);    // S0, S11, S9, S6, S3, S1, A
+  x2("\xFD\xBF\xBF\xBF\xBF\xBF", "\xFD\xBF\xBF\xBF\xBF\xBF", 0, 6);
+  x2("\\x{7FFFFFFF}", "\xFD\xBF\xBF\xBF\xBF\xBF", 0, 6); // max 6 bytes
+  
+  test_mbc_enc_len("\xFD\xC0\xBF\xBF\xBF\xBF", -1);   // S0, S11, F
+#endif
+
+  fprintf(stdout,
+       "\nRESULT   SUCC: %d,  FAIL: %d,  ERROR: %d      (by Onigmo %s)\n",
+       nsucc, nfail, nerror, onig_version());
+
+  onig_region_free(region, 1);
+  onig_end();
+
+  return ((nfail == 0 && nerror == 0) ? 0 : -1);
+}


### PR DESCRIPTION
This extends utf8 to 31bits.

Explanation of motivation is here https://github.com/k-takata/Onigmo/issues/110

I implemented logic with same manner on original 21 bits logic.

I add test program for testing utf-8 codec.

It can execute following steps. (at least in my mac environment)

```
$ aclocal
$ automake -ac
$ ./configure
$ make
$ make test_enc_utf8
$ ./test_enc_utf8
```

31bits mode is enabled by `USE_UTF8_31BITS` flag in `utf8.c`.
To ease testing this PR, I enabled it.
If this is accepted, I amend commit to disable it.

`USE_UTF8_31BITS` flag is also in `test_enc_utf8.c`.
We need to keep that these two flag have same.

Finally, I attached my memo to implement decoding table.

```
5 bytes
            111110yy 10yyyxxx 10xxxxxx 10xxxxxx 10xxxxxx 
min            
U+200000          00   001000   000000   000000   000000  26 bit
                  F8       88       80       80       80 
max
U+3FFFFFF         11   111111   111111   111111   111111  
                  FB       BF       BF       BF       BF 

6bytes
            1111110y 10yyyyxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
min            
U+4000000          0   000100   000000   000000   000000   000000  31 bit
                  FC       84       80       80       80       80
max
U+7FFFFFF          1   111111   111111   111111   111111   111111
                  FD       BF       BF       BF       BF       BF

サロゲートペア
U+D800 - U+DBFF, U+DC00 - U+DFFFをそのままコードポイントとして
UTF-8規則でエンコードすると
ED A0 80 - ED AF BF, ED B0 80 - ED BF BF



21bits(original)

S0: 最初の1バイト
      1バイト文字を見た → ACCEPT
      2バイト文字を見た → S1
      E0を見た → S2
      E1-EF(!ED) → S3
      ED → S4
      F0を見た → S5
      F1-F3を見た → S6
      F4を見た → S7
S1: 通常の後続バイトかどうか判定(1) 80-BF → ACCEPT
S2: 3バイト文字の2文字目だが、
    1バイト目のyyyyが000だったので、
    2バイト目のyの0が禁止。 A0-BF → S1
S3: 通常の後続バイトかどうか判定(2) 80-BF → S1
S4: A0-BFを見たらサロゲートペアなので、
    80-9Fだけ許可 → S1
S5: 4バイト文字の2文字目だが、
    1バイト目のyyyが000だったので、
    2バイト目のyyの00が禁止。90-BF → S3
S6: 通常の後続バイトかどうか判定(3) 80-BF → S3
S7: 1バイト目のyyyが100なので、
    U+10FFFF以下にするため、
    2バイト目のyyは00になる。80-8F → S3

31bits

 S0: 最初の1バイト
       1バイト文字を見た → ACCEPT
       2バイト文字を見た → S1
       E0を見た → S2
       E1-EF(!ED) → S3
       ED → S4
       F0を見た → S5
       F1-F7を見た → S6
       F8を見た → S8
       F9-FBを見た → S9
       FCを見た → S10
       FDを見た → S11
 S1: 通常の後続バイトかどうか判定(1) 80-BF → ACCEPT
 S2: 3バイト文字の2文字目だが、
     1バイト目のyyyyが000だったので、
     2バイト目のyの0が禁止。 A0-BF → S1
 S3: 通常の後続バイトかどうか判定(2) 80-BF → S1
 S4: A0-BFを見たらサロゲートペアなので、
     80-9Fだけ許可 → S1
 S5: 4バイト文字の2文字目だが、
     1バイト目のyyyが000だったので、
     2バイト目のyyの00が禁止。90-BF → S3
 S6: 通常の後続バイトかどうか判定(3) 80-BF → S3
 S8: 5バイト文字の2文字目だが、
     1バイト目のyyが00だったので、
     2バイト目のyyyの000が禁止。88-BF → S6
 S9: 通常の後続バイトかどうか判定(4) 80-BF → S6
S10: 6バイト文字の2文字目だが、
     1バイト目のyが0だったので、
     2バイト目のyyyyの0000が禁止。84-BF → S9
S11: 通常の後続バイトかどうか判定(5) 80-BF → S9
```


