### PR TITLE
Revert "[tune] implicit-anchor optimization"

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -5194,7 +5194,7 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       r = optimize_node_left(qn->target, &nopt, env);
       if (r) break;
 
-      if (/*qn->lower == 0 &&*/ IS_REPEAT_INFINITE(qn->upper)) {
+      if (qn->lower == 0 && IS_REPEAT_INFINITE(qn->upper)) {
 	if (env->mmd.max == 0 &&
 	    NTYPE(qn->target) == NT_CANY && qn->greedy) {
 	  if (IS_MULTILINE(env->options))


### PR DESCRIPTION
This reverts commit 282338f88a8bf0807a7a1d21b06f78abe9de8fac.
It seems that the commit didn't improve the performance.
Revert it to fix #100.