### PR TITLE
Fix lgtm.com warnings

### DIFF
--- a/enc/unicode.c
+++ b/enc/unicode.c
@@ -678,7 +678,7 @@ onigenc_unicode_case_map(OnigCaseFoldType* flagP,
     *pp += codepoint_length;
 
     if (code <= 'z') { /* ASCII comes first */
-      if (code >= 'a' && code <= 'z') {
+      if (code >= 'a' /*&& code <= 'z'*/) {
 	if (flags & ONIGENC_CASE_UPCASE) {
 	  MODIFIED;
 	  if (flags & ONIGENC_CASE_FOLD_TURKISH_AZERI && code == 'i')

--- a/regcomp.c
+++ b/regcomp.c
@@ -2770,10 +2770,8 @@ get_head_value_node(Node* node, int exact, regex_t* reg)
       if (sn->end <= sn->s)
 	break;
 
-      if (exact != 0 &&
-	  !NSTRING_IS_RAW(node) && IS_IGNORECASE(reg->options)) {
-      }
-      else {
+      if (exact == 0 ||
+	  NSTRING_IS_RAW(node) || !IS_IGNORECASE(reg->options)) {
 	n = node;
       }
     }
@@ -5036,7 +5034,7 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
 
 	if (NSTRING_IS_DONT_GET_OPT_INFO(node)) {
 	  int n = onigenc_strlen(env->enc, sn->s, sn->end);
-	  max = ONIGENC_MBC_MAXLEN_DIST(env->enc) * n;
+	  max = (OnigDistance )ONIGENC_MBC_MAXLEN_DIST(env->enc) * n;
 	}
 	else {
 	  concat_opt_exact_info_str(&opt->exb, sn->s, sn->end,

--- a/regexec.c
+++ b/regexec.c
@@ -1808,7 +1808,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
       /* default behavior: return first-matching result. */
       goto finish;
-      NEXT;
 
     CASE(OP_EXACT1)  MOP_IN(OP_EXACT1);
       DATA_ENSURE(1);
@@ -2369,7 +2368,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       goto fail;
-      NEXT;
 
     CASE(OP_ASCII_WORD_BEGIN)  MOP_IN(OP_ASCII_WORD_BEGIN);
       if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
@@ -2379,7 +2377,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       goto fail;
-      NEXT;
 
     CASE(OP_WORD_END)  MOP_IN(OP_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
@@ -2389,7 +2386,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       goto fail;
-      NEXT;
 
     CASE(OP_ASCII_WORD_END)  MOP_IN(OP_ASCII_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
@@ -2399,7 +2395,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	}
       }
       goto fail;
-      NEXT;
 #endif
 
     CASE(OP_BEGIN_BUF)  MOP_IN(OP_BEGIN_BUF);
@@ -2432,7 +2427,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	JUMP;
       }
       goto fail;
-      NEXT;
 
     CASE(OP_END_LINE)  MOP_IN(OP_END_LINE);
       if (ON_STR_END(s)) {
@@ -2451,7 +2445,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	JUMP;
       }
       goto fail;
-      NEXT;
 
     CASE(OP_SEMI_END_BUF)  MOP_IN(OP_SEMI_END_BUF);
       if (ON_STR_END(s)) {
@@ -2483,7 +2476,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
       }
       goto fail;
-      NEXT;
 
     CASE(OP_BEGIN_POSITION)  MOP_IN(OP_BEGIN_POSITION);
       if (s != msa->gpos)
@@ -2549,12 +2541,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_BACKREF1)  MOP_IN(OP_BACKREF1);
       mem = 1;
       goto backref;
-      NEXT;
 
     CASE(OP_BACKREF2)  MOP_IN(OP_BACKREF2);
       mem = 2;
       goto backref;
-      NEXT;
 
     CASE(OP_BACKREFN)  MOP_IN(OP_BACKREFN);
       GET_MEMNUM_INC(mem, p);
@@ -2964,7 +2954,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       STACK_GET_REPEAT(mem, stkp);
       si = GET_STACK_INDEX(stkp);
       goto repeat_inc;
-      NEXT;
 
     CASE(OP_REPEAT_INC_NG)  MOP_IN(OP_REPEAT_INC_NG);
       GET_MEMNUM_INC(mem, p); /* mem: OP_REPEAT ID */
@@ -2997,7 +2986,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       STACK_GET_REPEAT(mem, stkp);
       si = GET_STACK_INDEX(stkp);
       goto repeat_inc_ng;
-      NEXT;
 
     CASE(OP_PUSH_POS)  MOP_IN(OP_PUSH_POS);
       STACK_PUSH_POS(s, sprev, pkeep);
@@ -3022,7 +3010,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_FAIL_POS)  MOP_IN(OP_FAIL_POS);
       STACK_POP_TIL_POS_NOT;
       goto fail;
-      NEXT;
 
     CASE(OP_PUSH_STOP_BT)  MOP_IN(OP_PUSH_STOP_BT);
       STACK_PUSH_STOP_BT;
@@ -3063,7 +3050,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_FAIL_LOOK_BEHIND_NOT)  MOP_IN(OP_FAIL_LOOK_BEHIND_NOT);
       STACK_POP_TIL_LOOK_BEHIND_NOT;
       goto fail;
-      NEXT;
 
     CASE(OP_PUSH_ABSENT_POS)  MOP_IN(OP_PUSH_ABSENT_POS);
       /* Save the absent-start-pos and the original end-pos. */
@@ -3120,7 +3106,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
       STACK_POP_TIL_ABSENT;
       goto fail;
-      NEXT;
 
 #ifdef USE_SUBEXP_CALL
     CASE(OP_CALL)  MOP_IN(OP_CALL);
@@ -3150,7 +3135,6 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_FINISH)
       goto finish;
-      NEXT;
 
     CASE(OP_FAIL)
       if (0) {


### PR DESCRIPTION
Fix the following warnings:

* Multiplication result may overflow 'int' before it is converted to 'OnigDistance'.
* Comparison is always true because code <= 122.
* This statement makes ExprStmt unreachable.
* Empty block without comment