### PR TITLE
win32: Remove minor version from the py command

### DIFF
--- a/win32/Makefile
+++ b/win32/Makefile
@@ -43,7 +43,7 @@ RC = rc
 DEFS = -DHAVE_CONFIG_H -DEXPORT
 
 !if "$(ARCH)"=="x86"
-PYTHON = py -3.4-32
+PYTHON = py -3-32
 !else
 PYTHON = py -3
 !endif


### PR DESCRIPTION
From Python 3.7, the minor version number can be omitted from the py
command.