### PR TITLE
Add USE_CASE_MAP_API config

### DIFF
--- a/enc/ascii.c
+++ b/enc/ascii.c
@@ -54,7 +54,11 @@ OnigEncodingDefine(ascii, ASCII) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   ENCINDEX_ASCII,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/big5.c
+++ b/enc/big5.c
@@ -300,7 +300,11 @@ OnigEncodingDefine(big5, BIG5) = {
   onigenc_not_support_get_ctype_code_range,
   big5_left_adjust_char_head,
   big5_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };
@@ -335,7 +339,11 @@ OnigEncodingDefine(big5_hkscs, BIG5_HKSCS) = {
   onigenc_not_support_get_ctype_code_range,
   big5_left_adjust_char_head,
   big5_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };
@@ -370,7 +378,11 @@ OnigEncodingDefine(big5_uao, BIG5_UAO) = {
   onigenc_not_support_get_ctype_code_range,
   big5_left_adjust_char_head,
   big5_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/cp949.c
+++ b/enc/cp949.c
@@ -211,7 +211,11 @@ OnigEncodingDefine(cp949, CP949) = {
   onigenc_not_support_get_ctype_code_range,
   cp949_left_adjust_char_head,
   cp949_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/emacs_mule.c
+++ b/enc/emacs_mule.c
@@ -334,7 +334,11 @@ OnigEncodingDefine(emacs_mule, Emacs_Mule) = {
   onigenc_not_support_get_ctype_code_range,
   left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/euc_jp.c
+++ b/enc/euc_jp.c
@@ -576,7 +576,11 @@ OnigEncodingDefine(euc_jp, EUC_JP) = {
   get_ctype_code_range,
   left_adjust_char_head,
   is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/euc_kr.c
+++ b/enc/euc_kr.c
@@ -188,7 +188,11 @@ OnigEncodingDefine(euc_kr, EUC_KR) = {
   onigenc_not_support_get_ctype_code_range,
   euckr_left_adjust_char_head,
   euckr_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };
@@ -213,7 +217,11 @@ OnigEncodingDefine(euc_cn, EUC_CN) = {
   onigenc_not_support_get_ctype_code_range,
   euckr_left_adjust_char_head,
   euckr_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/euc_tw.c
+++ b/enc/euc_tw.c
@@ -221,7 +221,11 @@ OnigEncodingDefine(euc_tw, EUC_TW) = {
   onigenc_not_support_get_ctype_code_range,
   euctw_left_adjust_char_head,
   euctw_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/gb18030.c
+++ b/enc/gb18030.c
@@ -597,7 +597,11 @@ OnigEncodingDefine(gb18030, GB18030) = {
   onigenc_not_support_get_ctype_code_range,
   gb18030_left_adjust_char_head,
   gb18030_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/gbk.c
+++ b/enc/gbk.c
@@ -211,7 +211,11 @@ OnigEncodingDefine(gbk, GBK) = {
   onigenc_not_support_get_ctype_code_range,
   gbk_left_adjust_char_head,
   gbk_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_1.c
+++ b/enc/iso_8859_1.c
@@ -255,6 +255,7 @@ is_code_ctype(OnigCodePoint code, unsigned int ctype, OnigEncoding enc ARG_UNUSE
     return FALSE;
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -297,6 +298,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_1, ISO_8859_1) = {
   onigenc_single_byte_mbc_enc_len,
@@ -315,7 +317,11 @@ OnigEncodingDefine(iso_8859_1, ISO_8859_1) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_10.c
+++ b/enc/iso_8859_10.c
@@ -224,6 +224,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -269,6 +270,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_10, ISO_8859_10) = {
   onigenc_single_byte_mbc_enc_len,
@@ -287,7 +289,11 @@ OnigEncodingDefine(iso_8859_10, ISO_8859_10) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_11.c
+++ b/enc/iso_8859_11.c
@@ -93,7 +93,11 @@ OnigEncodingDefine(iso_8859_11, ISO_8859_11) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_13.c
+++ b/enc/iso_8859_13.c
@@ -217,6 +217,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -264,6 +265,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_13, ISO_8859_13) = {
   onigenc_single_byte_mbc_enc_len,
@@ -282,7 +284,11 @@ OnigEncodingDefine(iso_8859_13, ISO_8859_13) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_14.c
+++ b/enc/iso_8859_14.c
@@ -226,6 +226,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -280,6 +281,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_14, ISO_8859_14) = {
   onigenc_single_byte_mbc_enc_len,
@@ -298,7 +300,11 @@ OnigEncodingDefine(iso_8859_14, ISO_8859_14) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_15.c
+++ b/enc/iso_8859_15.c
@@ -220,6 +220,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -271,6 +272,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_15, ISO_8859_15) = {
   onigenc_single_byte_mbc_enc_len,
@@ -289,7 +291,11 @@ OnigEncodingDefine(iso_8859_15, ISO_8859_15) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_16.c
+++ b/enc/iso_8859_16.c
@@ -222,6 +222,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -275,6 +276,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_16, ISO_8859_16) = {
   onigenc_single_byte_mbc_enc_len,
@@ -293,7 +295,11 @@ OnigEncodingDefine(iso_8859_16, ISO_8859_16) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_2.c
+++ b/enc/iso_8859_2.c
@@ -220,6 +220,7 @@ is_code_ctype(OnigCodePoint code, unsigned int ctype, OnigEncoding enc ARG_UNUSE
     return FALSE;
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -266,6 +267,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_2, ISO_8859_2) = {
   onigenc_single_byte_mbc_enc_len,
@@ -284,7 +286,11 @@ OnigEncodingDefine(iso_8859_2, ISO_8859_2) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_3.c
+++ b/enc/iso_8859_3.c
@@ -220,6 +220,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 #define DOTLESS_i        (0xB9)
 #define I_WITH_DOT_ABOVE (0xA9)
 static int
@@ -276,6 +277,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_3, ISO_8859_3) = {
   onigenc_single_byte_mbc_enc_len,
@@ -294,7 +296,11 @@ OnigEncodingDefine(iso_8859_3, ISO_8859_3) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_4.c
+++ b/enc/iso_8859_4.c
@@ -223,6 +223,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -272,6 +273,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_4, ISO_8859_4) = {
   onigenc_single_byte_mbc_enc_len,
@@ -290,7 +292,11 @@ OnigEncodingDefine(iso_8859_4, ISO_8859_4) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_5.c
+++ b/enc/iso_8859_5.c
@@ -209,6 +209,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -240,6 +241,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_5, ISO_8859_5) = {
   onigenc_single_byte_mbc_enc_len,
@@ -258,7 +260,11 @@ OnigEncodingDefine(iso_8859_5, ISO_8859_5) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_6.c
+++ b/enc/iso_8859_6.c
@@ -93,7 +93,11 @@ OnigEncodingDefine(iso_8859_6, ISO_8859_6) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_7.c
+++ b/enc/iso_8859_7.c
@@ -205,6 +205,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -259,6 +260,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_7, ISO_8859_7) = {
   onigenc_single_byte_mbc_enc_len,
@@ -277,7 +279,11 @@ OnigEncodingDefine(iso_8859_7, ISO_8859_7) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_8.c
+++ b/enc/iso_8859_8.c
@@ -93,7 +93,11 @@ OnigEncodingDefine(iso_8859_8, ISO_8859_8) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/iso_8859_9.c
+++ b/enc/iso_8859_9.c
@@ -213,6 +213,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 #define DOTLESS_i        (0xFD)
 #define I_WITH_DOT_ABOVE (0xDD)
 static int
@@ -265,6 +266,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(iso_8859_9, ISO_8859_9) = {
   onigenc_single_byte_mbc_enc_len,
@@ -283,7 +285,11 @@ OnigEncodingDefine(iso_8859_9, ISO_8859_9) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/koi8_r.c
+++ b/enc/koi8_r.c
@@ -214,7 +214,11 @@ OnigEncodingDefine(koi8_r, KOI8_R) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/koi8_u.c
+++ b/enc/koi8_u.c
@@ -218,7 +218,11 @@ OnigEncodingDefine(koi8_u, KOI8_U) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/shift_jis.c
+++ b/enc/shift_jis.c
@@ -47,7 +47,11 @@ OnigEncodingDefine(shift_jis, Shift_JIS) = {
   get_ctype_code_range,
   left_adjust_char_head,
   is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/unicode.c
+++ b/enc/unicode.c
@@ -651,6 +651,7 @@ onigenc_unicode_get_case_fold_codes_by_str(OnigEncoding enc,
   return n;
 }
 
+#ifdef USE_CASE_MAP_API
 /* length in bytes for three characters in UTF-32; e.g. needed for ffi (U+FB03) */
 #define CASE_MAPPING_SLACK 12
 #define MODIFIED (flags |= ONIGENC_CASE_MODIFIED)
@@ -794,6 +795,7 @@ SpecialsCopy:
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 #if 0
 const char onigenc_unicode_version_string[] =

--- a/enc/us_ascii.c
+++ b/enc/us_ascii.c
@@ -32,7 +32,11 @@ OnigEncodingDefine(us_ascii, US_ASCII) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_single_byte_ascii_only_case_map,
+#else
+  NULL,
+#endif
   ENCINDEX_US_ASCII,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/utf_16be.c
+++ b/enc/utf_16be.c
@@ -249,7 +249,11 @@ OnigEncodingDefine(utf_16be, UTF_16BE) = {
   onigenc_utf16_32_get_ctype_code_range,
   utf16be_left_adjust_char_head,
   onigenc_always_false_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_unicode_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_UNICODE,
 };

--- a/enc/utf_16le.c
+++ b/enc/utf_16le.c
@@ -242,7 +242,11 @@ OnigEncodingDefine(utf_16le, UTF_16LE) = {
   onigenc_utf16_32_get_ctype_code_range,
   utf16le_left_adjust_char_head,
   onigenc_always_false_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_unicode_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_UNICODE,
 };

--- a/enc/utf_32be.c
+++ b/enc/utf_32be.c
@@ -199,7 +199,11 @@ OnigEncodingDefine(utf_32be, UTF_32BE) = {
   onigenc_utf16_32_get_ctype_code_range,
   utf32be_left_adjust_char_head,
   onigenc_always_false_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_unicode_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_UNICODE,
 };

--- a/enc/utf_32le.c
+++ b/enc/utf_32le.c
@@ -199,7 +199,11 @@ OnigEncodingDefine(utf_32le, UTF_32LE) = {
   onigenc_utf16_32_get_ctype_code_range,
   utf32le_left_adjust_char_head,
   onigenc_always_false_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_unicode_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_UNICODE,
 };

--- a/enc/utf_8.c
+++ b/enc/utf_8.c
@@ -568,7 +568,11 @@ OnigEncodingDefine(utf_8, UTF_8) = {
   get_ctype_code_range,
   left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_unicode_case_map,
+#else
+  NULL,
+#endif
   ENCINDEX_UTF_8,
   ONIGENC_FLAG_UNICODE,
 };

--- a/enc/windows_1250.c
+++ b/enc/windows_1250.c
@@ -190,6 +190,7 @@ cp1250_get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -239,6 +240,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1250, Windows_1250) = {
   onigenc_single_byte_mbc_enc_len,
@@ -257,7 +259,11 @@ OnigEncodingDefine(windows_1250, Windows_1250) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_1251.c
+++ b/enc/windows_1251.c
@@ -180,6 +180,7 @@ cp1251_get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -221,6 +222,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1251, Windows_1251) = {
   onigenc_single_byte_mbc_enc_len,
@@ -239,7 +241,11 @@ OnigEncodingDefine(windows_1251, Windows_1251) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_1252.c
+++ b/enc/windows_1252.c
@@ -181,6 +181,7 @@ cp1252_get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -228,6 +229,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1252, Windows_1252) = {
   onigenc_single_byte_mbc_enc_len,
@@ -246,7 +248,11 @@ OnigEncodingDefine(windows_1252, Windows_1252) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_1253.c
+++ b/enc/windows_1253.c
@@ -213,6 +213,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 static int
 case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
 	 const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
@@ -272,6 +273,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1253, Windows_1253) = {
   onigenc_single_byte_mbc_enc_len,
@@ -290,7 +292,11 @@ OnigEncodingDefine(windows_1253, Windows_1253) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_1254.c
+++ b/enc/windows_1254.c
@@ -221,6 +221,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 #define DOTLESS_i        (0xFD)
 #define I_WITH_DOT_ABOVE (0xDD)
 static int
@@ -277,6 +278,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1254, Windows_1254) = {
   onigenc_single_byte_mbc_enc_len,
@@ -295,7 +297,11 @@ OnigEncodingDefine(windows_1254, Windows_1254) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_1257.c
+++ b/enc/windows_1257.c
@@ -225,6 +225,7 @@ get_case_fold_codes_by_str(OnigCaseFoldType flag,
 	     flag, p, end, items);
 }
 
+#ifdef USE_CASE_MAP_API
 #define DOTLESS_i        (0xB9)
 #define I_WITH_DOT_ABOVE (0xA9)
 static int
@@ -279,6 +280,7 @@ case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif
 
 OnigEncodingDefine(windows_1257, Windows_1257) = {
   onigenc_single_byte_mbc_enc_len,
@@ -297,7 +299,11 @@ OnigEncodingDefine(windows_1257, Windows_1257) = {
   onigenc_not_support_get_ctype_code_range,
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/enc/windows_31j.c
+++ b/enc/windows_31j.c
@@ -48,7 +48,11 @@ OnigEncodingDefine(windows_31j, Windows_31J) = {
   get_ctype_code_range,
   left_adjust_char_head,
   is_allowed_reverse_match,
+#ifdef USE_CASE_MAP_API
   onigenc_ascii_only_case_map,
+#else
+  NULL,
+#endif
   0,
   ONIGENC_FLAG_NONE,
 };

--- a/regenc.c
+++ b/regenc.c
@@ -951,6 +951,7 @@ onigenc_property_list_add_property(UChar* name, const OnigCodePoint* prop,
 }
 #endif
 
+#ifdef USE_CASE_MAP_API
 extern int
 onigenc_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp, const OnigUChar* end,
 			    OnigUChar* to, OnigUChar* to_end, const struct OnigEncodingTypeST* enc)
@@ -1010,3 +1011,4 @@ onigenc_single_byte_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar
   *flagP = flags;
   return (int )(to - to_start);
 }
+#endif

--- a/regenc.h
+++ b/regenc.h
@@ -129,11 +129,13 @@ typedef struct {
 #endif
 
 
+/* config */
 #define USE_CRNL_AS_LINE_TERMINATOR
 #define USE_UNICODE_PROPERTIES
 #define USE_UNICODE_AGE_PROPERTIES
 /* #define USE_UNICODE_CASE_FOLD_TURKISH_AZERI */
 /* #define USE_UNICODE_ALL_LINE_TERMINATORS */  /* see Unicode.org UTS #18 */
+#define USE_CASE_MAP_API
 
 
 #define ONIG_ENCODING_INIT_DEFAULT           ONIG_ENCODING_ASCII


### PR DESCRIPTION
The case_map API is mainly (only?) used in Ruby.
Make it possible to disable the API.