### PR TITLE
Fix that onig_new() may crash

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -5824,6 +5824,12 @@ onig_reg_init(regex_t* reg, OnigOptionType option,
   if (IS_NULL(reg))
     return ONIGERR_INVALID_ARGUMENT;
 
+  (reg)->exact            = (UChar* )NULL;
+  (reg)->chain            = (regex_t* )NULL;
+  (reg)->p                = (UChar* )NULL;
+  (reg)->name_table       = (void* )NULL;
+  (reg)->repeat_range     = (OnigRepeatRange* )NULL;
+
   if (ONIGENC_IS_UNDEF(enc))
     return ONIGERR_DEFAULT_ENCODING_IS_NOT_SET;
 
@@ -5843,13 +5849,9 @@ onig_reg_init(regex_t* reg, OnigOptionType option,
   (reg)->options          = option;
   (reg)->syntax           = syntax;
   (reg)->optimize         = 0;
-  (reg)->exact            = (UChar* )NULL;
-  (reg)->chain            = (regex_t* )NULL;
 
-  (reg)->p                = (UChar* )NULL;
   (reg)->alloc            = 0;
   (reg)->used             = 0;
-  (reg)->name_table       = (void* )NULL;
 
   (reg)->case_fold_flag   = case_fold_flag;
   return 0;

--- a/testpy.py
+++ b/testpy.py
@@ -1333,7 +1333,7 @@ def main():
     # ONIG_OPTION_DONT_CAPTURE_GROUP option
     x2("(ab|cd)*", "cdab", 0, 4, opt=onigmo.ONIG_OPTION_DONT_CAPTURE_GROUP)
     n("(ab|cd)*\\1", "", opt=onigmo.ONIG_OPTION_DONT_CAPTURE_GROUP, err=onigmo.ONIGERR_INVALID_BACKREF)
-    #n("", "", opt=(onigmo.ONIG_OPTION_DONT_CAPTURE_GROUP | onigmo.ONIG_OPTION_CAPTURE_GROUP), err=onigmo.ONIGERR_INVALID_COMBINATION_OF_OPTIONS)  # FIXME: Python crashes on Windows
+    n("", "", opt=(onigmo.ONIG_OPTION_DONT_CAPTURE_GROUP | onigmo.ONIG_OPTION_CAPTURE_GROUP), err=onigmo.ONIGERR_INVALID_COMBINATION_OF_OPTIONS)
 
     # character classes (tests for character class optimization)
     x2("[@][a]", "@a", 0, 2);


### PR DESCRIPTION
When onig_reg_init() returns an error, onig_free_body() which is called
via onig_new() may crash because some members are not properly
initialized.  Fix it.