### PR TITLE
Fix SEGV in onig_error_code_to_str() (Fix #132)

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -3910,7 +3910,11 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
 	  if (c == 'R' || c == '0') {
 	    PINC;   /* skip 'R' / '0' */
-	    if (!PPEEK_IS(')')) return ONIGERR_INVALID_GROUP_NAME;
+	    if (!PPEEK_IS(')')) {
+	      r = ONIGERR_INVALID_GROUP_NAME;
+	      onig_scan_env_set_error_string(env, r, p - 1, p + 1);
+	      return r;
+	    }
 	    PINC;   /* skip ')' */
 	    name_end = name = p;
 	    gnum = 0;

--- a/testpy.py
+++ b/testpy.py
@@ -1320,6 +1320,7 @@ def main():
     n("\\M#", "", err=onigmo.ONIGERR_META_CODE_SYNTAX)
     n("\\C", "", err=onigmo.ONIGERR_END_PATTERN_AT_CONTROL)
     n("\\C#", "", err=onigmo.ONIGERR_CONTROL_CODE_SYNTAX)
+    n("(?0d", "", syn=onigmo.ONIG_SYNTAX_PERL, err=onigmo.ONIGERR_INVALID_GROUP_NAME) # Issue #132
 
     # ONIG_OPTION_FIND_LONGEST option
     x2("foo|foobar", "foobar", 0, 3)


### PR DESCRIPTION
When onig_new(ONIG_SYNTAX_PERL) fails with ONIGERR_INVALID_GROUP_NAME,
onig_error_code_to_str() crashes.
onig_scan_env_set_error_string() should have been used when returning
ONIGERR_INVALID_GROUP_NAME.