### PR TITLE
Fix out-of-bounds read in parse_char_class()

### DIFF
--- a/regenc.c
+++ b/regenc.c
@@ -625,18 +625,23 @@ onigenc_single_byte_mbc_to_code(const UChar* p, const UChar* end ARG_UNUSED,
 }
 
 extern int
-onigenc_single_byte_code_to_mbclen(OnigCodePoint code ARG_UNUSED, OnigEncoding enc ARG_UNUSED)
+onigenc_single_byte_code_to_mbclen(OnigCodePoint code, OnigEncoding enc ARG_UNUSED)
 {
+  if (code > 0xff)
+    return ONIGERR_INVALID_CODE_POINT_VALUE;
   return 1;
 }
 
 extern int
 onigenc_single_byte_code_to_mbc(OnigCodePoint code, UChar *buf, OnigEncoding enc ARG_UNUSED)
 {
+  if (code > 0xff) {
 #ifdef RUBY
-  if (code > 0xff)
     rb_raise(rb_eRangeError, "%u out of char range", code);
+#else
+    return ONIGERR_INVALID_CODE_POINT_VALUE;
 #endif
+  }
   *buf = (UChar )(code & 0xff);
   return 1;
 }

--- a/testpy.py
+++ b/testpy.py
@@ -1322,6 +1322,17 @@ def main():
     n("\\C", "", err=onigmo.ONIGERR_END_PATTERN_AT_CONTROL)
     n("\\C#", "", err=onigmo.ONIGERR_CONTROL_CODE_SYNTAX)
     n("(?0d", "", syn=onigmo.ONIG_SYNTAX_PERL, err=onigmo.ONIGERR_INVALID_GROUP_NAME) # Issue #132
+    if onig_encoding == onigmo.ONIG_ENCODING_UTF8:
+        n("\\x{1000000}", "", err=onigmo.ONIGERR_TOO_BIG_WIDE_CHAR_VALUE)
+    else:
+        n("\\x{1000000}", "")   # TODO: Should be an error? (code_to_mbc())
+    if onig_encoding == onigmo.ONIG_ENCODING_SJIS or \
+            onig_encoding == onigmo.ONIG_ENCODING_CP932 or \
+            onig_encoding == onigmo.ONIG_ENCODING_EUC_JP or \
+            onig_encoding == onigmo.ONIG_ENCODING_UTF8:
+        n("[\\x{1000000}]", "", err=onigmo.ONIGERR_TOO_BIG_WIDE_CHAR_VALUE)
+    else:
+        n("[\\x{1000000}]", "") # TODO: Should be an error? (code_to_mbclen())
 
     # ONIG_OPTION_FIND_LONGEST option
     x2("foo|foobar", "foobar", 0, 3)


### PR DESCRIPTION
This fixes #139.

/[\x{111111}]/ causes out-of-bounds read when encoding is a single byte
encoding. \x{111111} is an invalid codepoint for a single byte encoding.
Check if it is a valid codepoint.