### PR TITLE
docs: fix simple typo, strutures -> structures

### DIFF
--- a/st.h
+++ b/st.h
@@ -1,7 +1,7 @@
 /* This is a public domain general purpose hash table package
    originally written by Peter Moore @ UCB.
 
-   The hash table data strutures were redesigned and the package was
+   The hash table data structures were redesigned and the package was
    rewritten by Vladimir Makarov <vmakarov@redhat.com>.  */
 
 #ifndef RUBY_ST_H


### PR DESCRIPTION
There is a small typo in st.h.

Should read `structures` rather than `strutures`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md