### PR TITLE
Fix absence operator

### DIFF
--- a/regint.h
+++ b/regint.h
@@ -858,6 +858,7 @@ typedef struct _OnigStackType {
     struct {
       UChar *abs_pstr;        /* absent start position */
       const UChar *end_pstr;  /* end position */
+      const UChar *aend_prev; /* previous end position */
     } absent_pos;
   } u;
 } OnigStackType;

--- a/testpy.py
+++ b/testpy.py
@@ -1680,8 +1680,9 @@ def main():
     x2("(?~abc)", "abc", 0, 2)
     x2("(?~b)", "abc", 0, 1)
     x2("(?~abc|b)", "abc", 0, 1)
-    n("(?~|abc)", "abc")            # ???
-    x2("(?~abc|)", "abc", 0, 1)     # ???
+    n("(?~|abc)", "abc")
+    n("(?~abc|)", "abc")
+    n("^(?~.*)$", "abc")
     x2("(?~abc|def)x", "abcx", 1, 4)
     x2("(?~abc|def)x", "defx", 1, 4)
     x2("^(?~\\S+)TEST", "TEST", 0, 4)


### PR DESCRIPTION
Absense operator has missed shorter matches. (#150)

Fix the operator to search from the same start position when a temporary end position is updated.

