### PR TITLE
Fix out of bounds memory read in `onig_node_str_cat`

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -3323,6 +3323,7 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
   tok->backp = p;
 
   PFETCH(c);
+	if (p > end) return ONIGERR_PREMATURE_END_OF_CHAR_CLASS;
   if (IS_MC_ESC_CODE(c, syn)) {
     if (PEND) return ONIGERR_END_PATTERN_AT_ESCAPE;
 


### PR DESCRIPTION
This PR fixes out of bounds memory read in `onig_node_str_cat` revealed by fuzzing fluent-bit:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46049

The root cause is that a call to `enclen` inside of `PFETCH` macro when called in `fetch_token` results in a call to `onigenc_mbclen_approximate`.
When the value of `p` passed to the function is `\xec` even though it is the last byte in multibyte sequince (the next byte is unexpected string terminator \0) the `onigenc_mbclen_approximate` returns it's size as 4. The size is added to the overall string length and results in reading past the end of the string.

