### PR TITLE
Fix out of bounds memory read in `add_compile_string`

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -535,6 +535,9 @@ compile_string_node(Node* node, regex_t* reg)
     }
     else {
       r = add_compile_string(prev, prev_len, blen, reg, ambig);
+      if (p + len > end) {
+        return 0;
+      }
       if (r) return r;
 
       prev  = p;


### PR DESCRIPTION
This PR fixes out of bounds memory read in `add_compile_string` revealed by fuzzing fluent-bit:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46086

The root cause is that a call to `enclen` in `compile_string_node` results in a call to `onigenc_mbclen_approximate`.
When the value of `p` passed to the function is `\xf2` even though it is the last byte in multibyte sequince (the next byte is unexpected string terminator \0) the `onigenc_mbclen_approximate` returns it's size as 4. The size is added to the overall string length and results in reading past the end of the string.
